### PR TITLE
feat: arch()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://github.com/AldaronLau/semver).
 
+## [1.3.0] - Unreleased
+### Added
+ - `arch()` function which returns an `Arch` representing a CPU arch
+ - `Arch::width(&self)` function which returns the `Width` of a specific CPU arch
+
 ## [1.2.3] - 2022-09-12
 ### Fixed
  - WebAssembly target requiring older versions of dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@
 
 [package]
 name = "whoami"
-version = "1.2.3"
+version = "1.3.0"
 edition = "2018"
 license = "Apache-2.0 OR BSL-1.0 OR MIT"
 documentation = "https://docs.rs/whoami"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Check out the [documentation][0] for examples.
  - Get the devices's desktop environment
  - Get the devices's OS name and version
  - Get the devices's platform name
+ - Get the devices's CPU architecture and its width
 
 ### Supported Platforms
 WhoAmI targets all platforms that can run Rust, including:

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -12,7 +12,7 @@ use std::ffi::OsString;
 use wasm_bindgen::JsValue;
 use web_sys::window;
 
-use crate::{DesktopEnv, Platform};
+use crate::{Arch, DesktopEnv, Platform};
 
 // Get the user agent
 fn user_agent() -> Option<String> {
@@ -222,4 +222,13 @@ pub fn platform() -> Platform {
         // Platform::Redox,
         Platform::Unknown(string.to_string())
     }
+}
+
+pub fn arch() -> Arch {
+    #[cfg(target_pointer_width = "32")]
+    return Arch::Wasm32;
+    #[cfg(target_pointer_width = "64")]
+    return Arch::Wasm64;
+    #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
+    compile_error!("Arches other than wasm32 and wasm64 are not supported")
 }


### PR DESCRIPTION
## What this PR does
1. Add enum `Arch` to represent the CPU architecture (constructed by `arch()` function)
2. Add enum `Width` to represent the word width
3. Add function `Arch::arch_width(&self) -> Width` to get the width of a specific architecture

-------------------

## Architectures supported by each OS and Rust toolchain:

> The first field of 
> [Rust toolchain triple on `Linux/FreeBSD/DragonFly/NetBSD/OpenBSD/Windows/Wasm`](https://doc.rust-lang.org/nightly/rustc/platform-support.html)

#### Linux

1. aarch64
2. arm
3. armv4t
4. armv5te
5. armv7
6. thumbv7neon
7. armeb

8. i586
9. i686
10. x86_64

11. mips
12. mipsel
13. mips64
14. mips64el
15. mipsisa32r6
16. mipsisa32r6el

17. powerpc
18. powerpc64
19. powerpc64le

20. sparc
21. sparc64

22. hexagon
23. m68k

24. riscv32gc
25. riscv64gc

26. s390x

#### macOS

1. aarch64

2. i686
3. x86_64

#### FreeBSD

1. aarch64
2. armv6
3. armv7

4. i686
5. x86_64

6. powerpc
7. powerpc64
8. powerpc64le

9. riscv64gc

#### DragonflyBSD

1. x86_64

#### NetBSD

1. aarch64
2. armv6
3. armv7

4. i686
5. x86_64

6. powerpc
7. sparc64

#### OpenBSD

1. aarch64

2. i686
3. x86_64

4. powerpc
5. powerpc64

6. riscv64gc
7. sparc64

#### Windows

1. i586
2. i686
3. x86_64

4. aarch64

5. thumbv7a

#### Wasm
1. wasm32
2. wasm64

## Known Problems

1. Is `m68k` 16 bits or 32 bits?

   In my impl, I treat it as a 32-bit arch. 

   This chip is 32 bits internally and 16 bits externally.

   Ref:

   1. [wikipedia: Motorola 68000](https://en.wikipedia.org/wiki/Motorola_68000)
   3. [Is the 68000 unfairly labeled a 16-bit CPU?](https://forums.atariage.com/topic/278154-is-the-68000-unfairly-labeled-a-16-bit-cpu/)

2. Should `asm.js` be included? What is the width of this arch?

4. Rust does not have `i386-xxxxxx` toolchains for the OSes we are going to support

   > The only target starts with `i386` is `i386-apple-ios`.

   But this arch is still added in my impl as 
   [`uname -m` could return this value on Linux](https://stackoverflow.com/a/45125525/14092446)

5. Some variants of `Arch` may never be constructed, for example:

   1. ArmEb
   2. MipsIsa32R6,
   3. MipsIsa32R6El,
   4. ThumbV7A,
   6. ThumbV7Neon,
   7. ...

   I am not sure if `uname -m` will return such detailed architectures, for 
   example, for arch `MipsIsa32R6`, `uname -m` may just return `mips`? If so, then
   `MipsIsa32R6El` is never used.
