### PR TITLE
add arch() in examples & improve docs

### DIFF
--- a/examples/os-strings.rs
+++ b/examples/os-strings.rs
@@ -33,4 +33,8 @@ fn main() {
         "Device's Desktop Env.  whoami::desktop_env():     {:?}",
         whoami::desktop_env()
     );
+    println!(
+        "Device's CPU Arch      whoami::arch():            {:?}",
+        whoami::arch()
+    );
 }

--- a/examples/web/src/lib.rs
+++ b/examples/web/src/lib.rs
@@ -54,4 +54,8 @@ pub fn main() {
         "Device's Desktop Env.  whoami::desktop_env(): {}",
         whoami::desktop_env()
     ));
+    log(format!(
+        "Device's CPU Arch      whoami::arch():        {}",
+        whoami::arch()
+    ));
 }

--- a/examples/whoami-demo.rs
+++ b/examples/whoami-demo.rs
@@ -33,4 +33,8 @@ fn main() {
         "Device's Desktop Env.  whoami::desktop_env(): {}",
         whoami::desktop_env()
     );
+    println!(
+        "Device's CPU Arch      whoami::arch():        {}",
+        whoami::arch()
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,7 +427,7 @@ impl std::fmt::Display for Arch {
     }
 }
 
-/// Get CPU Architecture.
+/// Get the CPU Architecture.
 #[inline(always)]
 pub fn arch() -> Arch {
     native::arch()
@@ -453,7 +453,7 @@ impl std::fmt::Display for Width {
 }
 
 impl Arch {
-    /// The width of this architecture.
+    /// Get the width of this architecture.
     pub fn width(&self) -> io::Result<Width> {
         match self {
             Arch::Arm


### PR DESCRIPTION
<!--- Please describe the changes in the PR and the motivation below -->
<!--- Check CONTRIBUTING.md for more information-->

#### What this PR does:

1. Add examples for `arch()`
2. Some minor changes to the documentation of `arch()` and `Arch::width(&self)` to make them consistent with the existing functions