### PR TITLE
Add support for the Illumos platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ WhoAmI targets all platforms that can run Rust, including:
    - Web Browser - DOM
    - WASI - Wasite/Quantii, others **mock implementation, full implementation planned later**
    - Daku - Ardaku/Quantii, others **mock implementation, full implementation planned later**
+ - Illumos variants (SmartOS, OmniOS, others) **may partially or fully work - but untested**
  - Android **may partially or fully work - but untested, planned later**
  - iOS **planned later**
  - Redox **planned later**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,7 @@ pub enum Platform {
     // FIXME: Non-standard casing; Rename to 'Mac' rather than 'MacOs' in
     // whoami 2.0.0
     MacOS,
+    Illumos,
     Ios,
     Android,
     Nintendo,
@@ -228,6 +229,7 @@ impl Display for Platform {
             Platform::Bsd => "BSD",
             Platform::Windows => "Windows",
             Platform::MacOS => "Mac OS",
+            Platform::Illumos => "Illumos",
             Platform::Ios => "iOS",
             Platform::Android => "Android",
             Platform::Nintendo => "Nintendo",

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -307,7 +307,7 @@ pub(crate) fn devicename_os() -> OsString {
     devicename().into()
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_os = "illumos")))]
 pub(crate) fn devicename() -> String {
     let mut distro = String::new();
 
@@ -346,6 +346,18 @@ pub(crate) fn devicename_os() -> OsString {
         Ok(out)
     };
     fancy_fallback_os(computer)
+}
+
+#[cfg(target_os = "illumos")]
+pub(crate) fn devicename() -> String {
+    let mut nodename = String::new();
+
+    if let Ok(program) = std::fs::read_to_string("/etc/nodename") {
+        let program = program.into_bytes();
+        nodename.push_str(&String::from_utf8_lossy(&program));
+        nodename.pop();  // Remove the trailing newline
+    }
+    fancy_fallback(Err(hostname()))
 }
 
 pub(crate) fn hostname() -> String {
@@ -514,7 +526,8 @@ pub(crate) const fn platform() -> Platform {
     target_os = "dragonfly",
     target_os = "bitrig",
     target_os = "openbsd",
-    target_os = "netbsd"
+    target_os = "netbsd",
+    target_os = "illumos"
 )))]
 #[inline(always)]
 pub(crate) const fn platform() -> Platform {
@@ -531,6 +544,12 @@ pub(crate) const fn platform() -> Platform {
 #[inline(always)]
 pub(crate) const fn platform() -> Platform {
     Platform::Bsd
+}
+
+#[cfg(target_os = "illumos")]
+#[inline(always)]
+pub(crate) const fn platform() -> Platform {
+    Platform::Illumos
 }
 
 struct LangIter {
@@ -585,7 +604,8 @@ pub(crate) fn lang() -> impl Iterator<Item = String> {
     target_os = "freebsd",
     target_os = "dragonfly",
     target_os = "netbsd",
-    target_os = "openbsd"
+    target_os = "openbsd",
+    target_os = "illumos"
 ))]
 struct UtsName {
     #[cfg(not(target_os = "dragonfly"))]


### PR DESCRIPTION
Hello!

I run SmartOS, a distribution based on the Illumos OS, and recently one of the projects I rely on failed to build due to a dependency on this package. With this PR I am adding support for this platform, with a couple of caveats:
1. I am an extreme beginner with Rust, so my code builds, but it may very likely be incorrect. Code style is likely lacking.
2. I cannot guarantee that my implementation is complete. I looked around for all the `target_os` mentions and I think I covered them all. This may or may not be true.

As for the implementation details:
* Illumos, being forked from OpenSolaris, [follows its original definition](https://github.com/illumos/illumos-gate/blob/85fe9a719d390fcef3899d53f152b562c75d354f/usr/src/uts/common/sys/utsname.h#L52-L58) for the `utsname` struct, which is the same of *BSD.
* There is no systemd, so no `/etc/machine-info`, and for `devicename()` I am reading `/etc/nodename`. This usually matches the hostname, but not necessarily.

If any changes are needed to this PR kindly drop a comment, or feel free to edit it yourself if you prefer.

Thank you!