### PR TITLE
Fix Instances of Memory Corruption on Illumos

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -58,14 +58,14 @@ Expected output is
 WhoAmI 1.5.0-pre.0
 
 User's Language        whoami::langs():               
-User's Name            whoami::realname():            Unknown
-User's Username        whoami::username():            unknown
+User's Name            whoami::realname():            Tribblix Jack
+User's Username        whoami::username():            jack
 Device's Pretty Name   whoami::devicename():          tribblix
 Device's Hostname      whoami::fallible::hostname():  tribblix
 Device's Platform      whoami::platform():            Illumos
 Device's OS Distro     whoami::distro():              Tribblix
 Device's Desktop Env.  whoami::desktop_env():         Unknown: Unknown
-Device's CPU Arch      whoami::arch():                Unknown: 
+Device's CPU Arch      whoami::arch():                Unknown: i86pc
 ```
 
 ## Redox

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,6 +2,28 @@
 
 This file outlines the regression testing plan for all platforms.
 
+## Linux / Fedora Silverblue
+
+## Linux / Ubuntu
+
+## Windows
+
+## MacOS
+
+## FreeBSD
+
+## Illumos
+
+Testing is done on Tribblix (virtualized on Fedora Silverblue):
+
+<http://www.tribblix.org/download.html>
+
+Download the 64-bit x86/x64 standard image.
+
+Install it in GNOME Boxes.
+
+
+
 ## Redox
 
 <https://doc.redox-os.org/book/ch08-01-advanced-build.html#understanding-cross-compilation-for-redox>

--- a/TESTING.md
+++ b/TESTING.md
@@ -20,9 +20,53 @@ Testing is done on Tribblix (virtualized on Fedora Silverblue):
 
 Download the 64-bit x86/x64 standard image.
 
-Install it in GNOME Boxes.
+Install it in GNOME Boxes (select operating system OpenIndiana Hipster).
 
+Set 4 GiB memory, and 16 GiB Storage limit
 
+Login as `jack` (password `jack`)
+
+```shell
+su - root # password `tribblix`
+format # 0, quit
+./live_install -G c1t0d0 develop # replace c1t0d0 with disk
+reboot -p
+```
+
+Login as `jack` (password `jack`)
+
+Now, install Rust (use bash instead of sh, sh doesn't work)
+
+```shell
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash # 1
+source "$HOME/.cargo/env"
+```
+
+### Testing
+
+```shell
+git clone https://github.com/ardaku/whoami.git
+cd whoami
+# run both debug and release
+cargo run --example whoami-demo
+cargo run --example whoami-demo --release
+```
+
+Expected output is
+
+```console
+WhoAmI 1.5.0-pre.0
+
+User's Language        whoami::langs():               
+User's Name            whoami::realname():            Unknown
+User's Username        whoami::username():            unknown
+Device's Pretty Name   whoami::devicename():          tribblix
+Device's Hostname      whoami::fallible::hostname():  tribblix
+Device's Platform      whoami::platform():            Illumos
+Device's OS Distro     whoami::distro():              Tribblix
+Device's Desktop Env.  whoami::desktop_env():         Unknown: Unknown
+Device's CPU Arch      whoami::arch():                Unknown: 
+```
 
 ## Redox
 

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -29,7 +29,8 @@ use crate::{
     target_os = "dragonfly",
     target_os = "bitrig",
     target_os = "openbsd",
-    target_os = "netbsd"
+    target_os = "netbsd",
+    target_os = "illumos",
 )))]
 #[repr(C)]
 struct PassWd {
@@ -63,6 +64,20 @@ struct PassWd {
     pw_shell: *const c_void,
     pw_expire: isize,
     pw_fields: i32,
+}
+
+#[cfg(target_os = "illumos")]
+#[repr(C)]
+struct PassWd {
+     pw_name: *const c_void, 
+     pw_passwd: *const c_void, 
+     pw_uid: u32,
+     pw_gid: u32,
+     pw_age: *const c_void, 
+     pw_comment: *const c_void, 
+     pw_gecos: *const c_void, 
+     pw_dir: *const c_void, 
+     pw_shell: *const c_void,
 }
 
 extern "system" {

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -69,15 +69,15 @@ struct PassWd {
 #[cfg(target_os = "illumos")]
 #[repr(C)]
 struct PassWd {
-     pw_name: *const c_void, 
-     pw_passwd: *const c_void, 
-     pw_uid: u32,
-     pw_gid: u32,
-     pw_age: *const c_void, 
-     pw_comment: *const c_void, 
-     pw_gecos: *const c_void, 
-     pw_dir: *const c_void, 
-     pw_shell: *const c_void,
+    pw_name: *const c_void,
+    pw_passwd: *const c_void,
+    pw_uid: u32,
+    pw_gid: u32,
+    pw_age: *const c_void,
+    pw_comment: *const c_void,
+    pw_gecos: *const c_void,
+    pw_dir: *const c_void,
+    pw_shell: *const c_void,
 }
 
 extern "system" {


### PR DESCRIPTION
In the future it would be nice to use libc (once an MSRV policy is decided on that's compatible with whoami 1.0's MSRV guarantees) or nix (in whoami 2.1), but for now doing a minimal patch.

Also, supporting Illumos as a tested target.