### PR TITLE
Remove comment about hostname being limited to ASCII

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -78,8 +78,10 @@ pub fn devicename_os() -> OsString {
 
 /// Get the host device's hostname.
 ///
-/// Usually hostnames are case-insensitive, but it's
-/// not a hard requirement.
+/// This method normalizes to lowercase.  Usually hostnames are
+/// case-insensitive, but it's not a hard requirement.
+///
+/// FIXME: Document platform-specific character limitations
 ///
 /// Use [`fallible::hostname()`] for case-sensitive hostname.
 #[inline(always)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -78,10 +78,8 @@ pub fn devicename_os() -> OsString {
 
 /// Get the host device's hostname.
 ///
-/// Limited to a-z (case insensitive), 0-9, and dashes.  This limit also applies
-/// to `devicename()` with the exeception of case sensitivity when targeting
-/// Windows.  This method normalizes to lowercase.  Usually hostnames will be
-/// case-insensitive, but it's not a hard requirement.
+/// Usually hostnames are case-insensitive, but it's
+/// not a hard requirement.
 ///
 /// Use [`fallible::hostname()`] for case-sensitive hostname.
 #[inline(always)]
@@ -96,10 +94,8 @@ pub fn hostname() -> String {
 
 /// Get the host device's hostname.
 ///
-/// Limited to a-z (case insensitive), 0-9, and dashes.  This limit also applies
-/// to `devicename()` with the exeception of case sensitivity when targeting
-/// Windows.  This method normalizes to lowercase.  Usually hostnames will be
-/// case-insensitive, but it's not a hard requirement.
+/// Usually hostnames are case-insensitive, but it's
+/// not a hard requirement.
 ///
 /// Use [`fallible::hostname()`] for case-sensitive hostname.
 #[inline(always)]

--- a/src/fallible.rs
+++ b/src/fallible.rs
@@ -92,6 +92,8 @@ pub fn devicename_os() -> Result<OsString> {
 ///
 /// Usually hostnames are case-insensitive, but it's
 /// not a hard requirement.
+///
+/// FIXME: Document platform-specific character limitations
 #[inline(always)]
 pub fn hostname() -> Result<String> {
     Target::hostname(Os)

--- a/src/fallible.rs
+++ b/src/fallible.rs
@@ -90,9 +90,8 @@ pub fn devicename_os() -> Result<OsString> {
 
 /// Get the host device's hostname.
 ///
-/// Limited to a-z, A-Z, 0-9, and dashes.  This limit also applies to
-/// [`devicename()`] when targeting Windows.  Usually hostnames are
-/// case-insensitive, but it's not a hard requirement.
+/// Usually hostnames are case-insensitive, but it's
+/// not a hard requirement.
 #[inline(always)]
 pub fn hostname() -> Result<String> {
     Target::hostname(Os)


### PR DESCRIPTION
<!--- Please describe the changes in the PR and the motivation below -->
<!--- Check CONTRIBUTING.md for more information-->

On Windows, the Computer Name can be set to emoji and other Unicode characters, and a call to the `whoami` `hostname`-APIs will return that value.
