### PR TITLE
Add support for GNU/Hurd

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ WhoAmI targets all platforms that can run Rust, including:
  - Android **planned later**
  - iOS / watchOS / tvOS **planned later**
  - Fuchsia **planned later**
+ - GNU/Hurd **untested**
  - Others? (make a PR or open an issue)
 
 ## MSRV

--- a/src/os.rs
+++ b/src/os.rs
@@ -18,6 +18,7 @@
             target_os = "netbsd",
             target_os = "openbsd",
             target_os = "illumos",
+            target_os = "hurd",
         ),
         not(target_arch = "wasm32")
     ),

--- a/src/os/target.rs
+++ b/src/os/target.rs
@@ -92,7 +92,7 @@ impl Target for Os {
         } else if cfg!(target_os = "vita") {
             Platform::PlayStation
         } else if cfg!(target_os = "hurd") {
-            Platform::Unknown("GNU Hurd".to_string())
+            Platform::Hurd
         } else if cfg!(target_os = "aix") {
             Platform::Unknown("AIX OS".to_string())
         } else if cfg!(target_os = "espidf") {

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -7,6 +7,7 @@ use std::convert::TryInto;
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "illumos",
+    target_os = "hurd",
 ))]
 use std::env;
 use std::{
@@ -34,7 +35,7 @@ use crate::{
     Arch, DesktopEnv, Platform, Result,
 };
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "hurd",))]
 #[repr(C)]
 struct PassWd {
     pw_name: *const c_void,
@@ -99,6 +100,7 @@ extern "system" {
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "openbsd",
+    target_os = "hurd",
 ))]
 extern "system" {
     fn getpwuid_r(
@@ -250,6 +252,7 @@ fn getpwuid(name: Name) -> Result<OsString> {
             target_os = "freebsd",
             target_os = "netbsd",
             target_os = "openbsd",
+            target_os = "hurd",
         ))]
         {
             let mut _passwd = mem::MaybeUninit::<*mut PassWd>::uninit();
@@ -403,6 +406,16 @@ struct UtsName {
     domainname: [c_char; 65],
 }
 
+#[cfg(target_os = "hurd")]
+#[repr(C)]
+struct UtsName {
+    sysname: [c_char; 1024],
+    nodename: [c_char; 1024],
+    release: [c_char; 1024],
+    version: [c_char; 1024],
+    machine: [c_char; 1024],
+}
+
 // Buffer initialization
 impl Default for UtsName {
     fn default() -> Self {
@@ -420,6 +433,7 @@ unsafe fn uname(buf: *mut UtsName) -> c_int {
             target_os = "netbsd",
             target_os = "openbsd",
             target_os = "illumos",
+            target_os = "hurd",
         ))]
         fn uname(buf: *mut UtsName) -> c_int;
 
@@ -486,6 +500,7 @@ impl Target for Os {
             target_os = "freebsd",
             target_os = "netbsd",
             target_os = "openbsd",
+            target_os = "hurd",
         ))]
         {
             let machine_info = fs::read("/etc/machine-info")?;
@@ -545,6 +560,7 @@ impl Target for Os {
             target_os = "netbsd",
             target_os = "openbsd",
             target_os = "illumos",
+            target_os = "hurd",
         ))]
         {
             let program = fs::read("/etc/os-release")?;
@@ -591,6 +607,7 @@ impl Target for Os {
             target_os = "netbsd",
             target_os = "openbsd",
             target_os = "illumos",
+            target_os = "hurd",
         ))]
         let env = env::var_os("DESKTOP_SESSION");
         #[cfg(any(
@@ -600,6 +617,7 @@ impl Target for Os {
             target_os = "netbsd",
             target_os = "openbsd",
             target_os = "illumos",
+            target_os = "hurd",
         ))]
         let env = if let Some(ref env) = env {
             env.to_string_lossy()
@@ -652,6 +670,11 @@ impl Target for Os {
         #[cfg(target_os = "illumos")]
         {
             Platform::Illumos
+        }
+
+        #[cfg(target_os = "hurd")]
+        {
+            Platform::Hurd
         }
     }
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -22,6 +22,7 @@ pub enum Platform {
     PlayStation,
     Fuchsia,
     Redox,
+    Hurd,
     Unknown(String),
 }
 
@@ -44,6 +45,7 @@ impl Display for Platform {
             Self::PlayStation => "PlayStation",
             Self::Fuchsia => "Fuchsia",
             Self::Redox => "Redox",
+            Self::Hurd => "GNU Hurd",
             Self::Unknown(a) => a,
         })
     }


### PR DESCRIPTION
- add a new `Platform` item for it, and use it explicitly
- use the `unix` module, since it provides all the needed bits
- tweak the `unix` module for what is supported by Hurd, mostly following what Linux does and using an own `UtsName` (according to the `utsname` implementation in GNU libc)