### PR TITLE
Use std::ffi everywhere instead of std::os::raw

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bumpalo"
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rust-version = "1.65"
 
 # Target specific dependency for redox
 [target.'cfg(all(target_os = "redox", not(target_arch = "wasm32")))'.dependencies.redox_syscall]
-version = "0.4"
+version = "0.5"
 
 # Target specific dependency for wasite
 [target.'cfg(all(target_arch = "wasm32", target_os = "wasi"))'.dependencies.wasite]

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -8,8 +8,7 @@
 ))]
 use std::env;
 use std::{
-    ffi::{c_char, c_int},
-    ffi::{c_void, CStr, OsString},
+    ffi::{c_char, c_int, c_void, CStr, OsString},
     fs,
     io::{Error, ErrorKind},
     mem,

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -8,22 +8,18 @@
 ))]
 use std::env;
 use std::{
+    ffi::{c_char, c_int},
     ffi::{c_void, CStr, OsString},
     fs,
     io::{Error, ErrorKind},
     mem,
-    os::{
-        raw::{c_char, c_int},
-        unix::ffi::OsStringExt,
-    },
+    os::unix::ffi::OsStringExt,
     slice,
 };
 #[cfg(target_os = "macos")]
 use std::{
-    os::{
-        raw::{c_long, c_uchar},
-        unix::ffi::OsStrExt,
-    },
+    ffi::{c_long, c_uchar},
+    os::unix::ffi::OsStrExt,
     ptr::null_mut,
 };
 

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -1,6 +1,5 @@
 use std::{
-    ffi::OsString,
-    ffi::{c_char, c_int, c_uchar, c_ulong, c_ushort, c_void},
+    ffi::{c_char, c_int, c_uchar, c_ulong, c_ushort, c_void, OsString},
     io::{Error, ErrorKind},
     mem::MaybeUninit,
     os::windows::ffi::OsStringExt,

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -1,11 +1,9 @@
 use std::{
     ffi::OsString,
+    ffi::{c_char, c_int, c_uchar, c_ulong, c_ushort, c_void},
     io::{Error, ErrorKind},
     mem::MaybeUninit,
-    os::{
-        raw::{c_char, c_int, c_uchar, c_ulong, c_ushort, c_void},
-        windows::ffi::OsStringExt,
-    },
+    os::windows::ffi::OsStringExt,
     ptr,
 };
 


### PR DESCRIPTION
Replace usage of `std::os::raw` with `std::ffi` for C types.
Fixes #75.
