### PR TITLE
Adjusts `langs()` to match POSIX locale spec

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -138,7 +138,7 @@ pub fn langs() -> Result<impl Iterator<Item = Language>> {
     // FIXME: Could do less allocation
     let langs = Target::langs(Os)?;
     let langs = langs
-        .split(';')
+        .split(':')
         .map(ToString::to_string)
         .filter_map(|lang| {
             let lang = lang

--- a/src/language.rs
+++ b/src/language.rs
@@ -31,7 +31,8 @@ impl Display for Country {
 /// language code followed an forward slash and uppercase country code (example:
 /// `en/US`).
 ///
-/// Uses <https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes>
+/// Language codes defined in ISO 639 <https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes>,
+/// Country codes defined in ISO 3166 <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>
 #[non_exhaustive]
 #[derive(Clone, Eq, PartialEq, Debug)]
 // #[allow(variant_size_differences)]

--- a/src/os.rs
+++ b/src/os.rs
@@ -115,10 +115,18 @@ fn unix_lang() -> Result<String> {
             Error::new(kind, e)
         })
     };
-    let langs = check_var("LC_ALL")
-        .or_else(|_| check_var("LANGS"))
-        .or_else(|_| check_var("LANG"))
-        .or_else(|_| check_var("LANGUAGE"))?;
+
+    // Uses priority defined in
+    // <https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html>
+    let locale = check_var("LC_ALL").or_else(|_| check_var("LANG"));
+
+    // The LANGUAGE environment variable takes precedence if and only if
+    // localization is enabled, i.e., LC_ALL / LANG is not "C".
+    // <https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html>
+    let langs = match &locale {
+        Ok(loc) if loc != "C" => check_var("LANGUAGE").or(locale),
+        _ => locale,
+    }?;
 
     if langs.is_empty() {
         return Err(err_empty_record());


### PR DESCRIPTION
Adjusts `langs()` function to follow the [GNU spec for setting locale variables](https://www.gnu.org/software/gettext/manual/html_node/Setting-the-POSIX-Locale.html)

Motivated by discussion in issue #145 