### PR TITLE
Add ability to get language prefs for categories

### DIFF
--- a/examples/os-strings.rs
+++ b/examples/os-strings.rs
@@ -2,12 +2,8 @@ fn main() {
     println!("WhoAmI {}", env!("CARGO_PKG_VERSION"));
     println!();
     println!(
-        "User's Language        whoami::langs():                 {:?}",
-        whoami::langs()
-            .map(|l| {
-                l.map(|l| l.to_string()).collect::<Vec<String>>().join(", ")
-            })
-            .unwrap_or_else(|_| "??".to_string()),
+        "User's Language        whoami::lang_prefs():            {:?}",
+        whoami::lang_prefs().unwrap_or_default()
     );
     println!(
         "User's Name            whoami::realname_os():           {:?}",

--- a/examples/web/src/lib.rs
+++ b/examples/web/src/lib.rs
@@ -25,12 +25,8 @@ pub fn main() {
         whoami::username(),
     ));
     log(format!(
-        "User's Language        whoami::langs():               {}",
-        whoami::langs()
-            .map(|l| {
-                l.map(|l| l.to_string()).collect::<Vec<String>>().join(", ")
-            })
-            .unwrap_or_else(|_| "??".to_string()),
+        "User's Language        whoami::lang_prefs():          {}",
+        whoami::lang_prefs().unwrap_or_default(),
     ));
     log(format!(
         "Device's Pretty Name   whoami::devicename():          {}",

--- a/examples/whoami-demo.rs
+++ b/examples/whoami-demo.rs
@@ -2,12 +2,8 @@ fn main() {
     println!("WhoAmI {}", env!("CARGO_PKG_VERSION"));
     println!();
     println!(
-        "User's Language        whoami::langs():               {}",
-        whoami::langs()
-            .map(|l| {
-                l.map(|l| l.to_string()).collect::<Vec<String>>().join(", ")
-            })
-            .unwrap_or_else(|_| "??".to_string()),
+        "User's Language        whoami::lang_prefs():          {}",
+        whoami::lang_prefs().unwrap_or_default()
     );
     println!(
         "User's Name            whoami::realname():            {}",

--- a/src/api.rs
+++ b/src/api.rs
@@ -3,7 +3,7 @@ use std::{env, ffi::OsString};
 use crate::{
     conversions,
     os::{Os, Target},
-    Arch, DesktopEnv, Language, Platform, Result,
+    Arch, DesktopEnv, LanguagePrefs, Platform, Result,
 };
 
 macro_rules! report_message {
@@ -130,29 +130,9 @@ pub fn platform() -> Platform {
 
 /// Get the user's preferred language(s).
 ///
-/// Returned as iterator of [`Language`]s.  The most preferred language is
-/// returned first, followed by next preferred, and so on.  Unrecognized
-/// languages may either return an error or be skipped.
+/// Returned as a [`LanguagePrefs`].  Unrecognized languages may
+/// either return an error or be skipped.
 #[inline(always)]
-pub fn langs() -> Result<impl Iterator<Item = Language>> {
-    // FIXME: Could do less allocation
-    let langs = Target::langs(Os)?;
-    let langs = langs
-        .split(':')
-        .map(ToString::to_string)
-        .filter_map(|lang| {
-            let lang = lang
-                .split_terminator('.')
-                .next()
-                .unwrap_or_default()
-                .replace(|x| ['_', '-'].contains(&x), "/");
-
-            if lang == "C" {
-                return None;
-            }
-
-            Some(Language::__(Box::new(lang)))
-        });
-
-    Ok(langs.collect::<Vec<_>>().into_iter())
+pub fn lang_prefs() -> Result<LanguagePrefs> {
+    Target::lang_prefs(Os)
 }

--- a/src/language.rs
+++ b/src/language.rs
@@ -57,6 +57,22 @@ impl Language {
     }
 }
 
+// Reads an `language_COUNTRY.Encoding` formatted string into a Language where
+// language is a two letter language code and country is a two letter country
+// code.
+impl<T: AsRef<str>> From<T> for Language {
+    // FIXME: Could do less allocation
+    fn from(item: T) -> Self {
+        let lang = item
+            .as_ref()
+            .split_terminator('.')
+            .next()
+            .unwrap_or_default()
+            .replace(|x| ['_', '-'].contains(&x), "/");
+        Self::__(Box::new(lang))
+    }
+}
+
 impl Display for Language {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
@@ -78,5 +94,146 @@ impl Display for Language {
                 }
             }
         }
+    }
+}
+
+/// [`Language`] preferences for a user.
+///
+/// Fields are sorted in order of the user's preference.
+///
+/// POSIX locale values and GNU nonstandard categories are defined in
+/// <https://man7.org/linux/man-pages/man7/locale.7.html>. Windows locale values
+/// are defined in <https://learn.microsoft.com/en-us/cpp/c-runtime-library/locale-categories>.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct LanguagePrefs {
+    /// Determines general user language preference, should be used in
+    /// situations which are not encompassed by other [`LanguagePrefs`].
+    pub(crate) fallbacks: Vec<Language>,
+
+    /// Determines collation rules used for sorting and regular expressions,
+    /// including character equivalence classes and multicharacter collating
+    /// elements.
+    pub(crate) collation: Option<Language>,
+
+    /// Determines the interpretation of byte sequences as characters (e.g.,
+    /// single versus multibyte characters), character classifications (e.g.,
+    /// alphabetic or digit), and the behavior of character classes.
+    pub(crate) char_classes: Option<Language>,
+
+    /// Determines the formatting used for monetary-related numeric values,
+    /// i.e, the way numbers are usually printed with details such as
+    /// decimal point versus decimal comma.
+    pub(crate) monetary: Option<Language>,
+
+    /// Determines the language in which messages are
+    /// displayed and what an affirmative or negative answer looks
+    /// like.
+    pub(crate) messages: Option<Language>,
+
+    /// Determines the formatting rules used for nonmonetary numeric values.
+    /// For example, the thousands separator and the radix character.
+    pub(crate) numeric: Option<Language>,
+
+    /// Determines format and contents of date and time information.
+    pub(crate) time: Option<Language>,
+}
+
+impl Display for LanguagePrefs {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let langs: [(&str, Vec<Language>); 6] = [
+            ("Collation", self.collation_langs().collect()),
+            ("CharClasses", self.char_class_langs().collect()),
+            ("Monetary", self.monetary_langs().collect()),
+            ("Messages", self.message_langs().collect()),
+            ("Numeric", self.numeric_langs().collect()),
+            ("Time", self.time_langs().collect()),
+        ];
+        for (i, (name, langs)) in langs.iter().enumerate() {
+            if i != 0 {
+                f.write_str(",")?;
+            }
+            f.write_str(name)?;
+            for (j, lang) in langs.iter().enumerate() {
+                if j != 0 {
+                    f.write_str(":")?;
+                }
+                write!(f, "{}", lang)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl LanguagePrefs {
+    fn chain_fallbacks<'a>(
+        &'a self,
+        l: &Option<Language>,
+    ) -> impl Iterator<Item = Language> + 'a {
+        l.clone().into_iter().chain(self.fallbacks.iter().cloned())
+    }
+
+    /// Returns the collation langs of this [`LanguagePrefs`] in order of the
+    /// user's preference
+    ///
+    /// Collation langs are used for sorting and regular expressions,
+    /// including character equivalence classes and multicharacter collating
+    /// elements.
+    pub fn collation_langs(&self) -> impl Iterator<Item = Language> + '_ {
+        self.chain_fallbacks(&self.collation)
+    }
+
+    /// Returns the char class langs of this [`LanguagePrefs`] in order of the
+    /// user's preference
+    ///
+    /// Char class langs determine the interpretation of byte sequences as
+    /// characters (e.g., single versus multibyte characters), character
+    /// classifications (e.g., alphabetic or digit), and the behavior of
+    /// character classes.
+    pub fn char_class_langs(&self) -> impl Iterator<Item = Language> + '_ {
+        self.chain_fallbacks(&self.char_classes)
+    }
+
+    /// Returns the monetary langs of this [`LanguagePrefs`] in order of the
+    /// user's preference
+    ///
+    /// Monetary langs determine the formatting used for monetary-related
+    /// numeric values, i.e, the way numbers are usually printed with details
+    /// such as decimal point versus decimal comma.
+    ///
+    /// For nonmonetary numeric values, see [`LanguagePrefs::numeric_langs`]
+    pub fn monetary_langs(&self) -> impl Iterator<Item = Language> + '_ {
+        self.chain_fallbacks(&self.monetary)
+    }
+
+    /// Returns the messages langs of this [`LanguagePrefs`] in order of the
+    /// user's preference
+    ///
+    /// Message determines the language in which messages are
+    /// displayed and what an affirmative or negative answer looks
+    /// like.
+    pub fn message_langs(&self) -> impl Iterator<Item = Language> + '_ {
+        self.chain_fallbacks(&self.messages)
+    }
+
+    /// Returns the numeric langs of this [`LanguagePrefs`] in order of the
+    /// user's preference
+    ///
+    /// Numeric langs determine the formatting rules used for nonmonetary
+    /// numeric values. For example, the thousands separator and the radix
+    /// character.
+    ///
+    /// For monetary formatting, see [`LanguagePrefs::monetary_langs`].
+    pub fn numeric_langs(&self) -> impl Iterator<Item = Language> + '_ {
+        self.chain_fallbacks(&self.numeric)
+    }
+
+    /// Returns the time langs of this [`LanguagePrefs`] in order of the user's
+    /// preference
+    ///
+    /// Time langs determine format and contents of date and time information.
+    pub fn time_langs(&self) -> impl Iterator<Item = Language> + '_ {
+        self.chain_fallbacks(&self.time)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,18 +4,14 @@
 //! Using the whoami crate is super easy!  All of the public items are simple
 //! functions with no parameters that return [`String`]s or [`OsString`]s (with
 //! the exception of [`desktop_env()`], [`platform()`], and [`arch()`], which
-//! return enums, and [`langs()`] that returns an iterator of [`String`]s).  The
-//! following example shows how to use all of the functions (except those that
-//! return [`OsString`]):
+//! return enums, and [`lang_prefs()`] that returns [`LanguagePrefs`]).
+//! The following example shows how to use all of the functions (except those
+//! that return [`OsString`]):
 //!
 //! ```rust
 //! println!(
-//!     "User's Language        whoami::langs():               {}",
-//!     whoami::langs()
-//!         .map(|l| {
-//!             l.map(|l| l.to_string()).collect::<Vec<String>>().join(", ")
-//!         })
-//!         .unwrap_or_else(|_| "??".to_string()),
+//!     "User's Language        whoami::lang_prefs():          {}",
+//!     whoami::lang_prefs().unwrap_or_default(),
 //! );
 //! println!(
 //!     "User's Name            whoami::realname():            {}",
@@ -104,12 +100,12 @@ mod result;
 pub use self::{
     api::{
         account, account_os, arch, desktop_env, devicename, devicename_os,
-        distro, hostname, langs, platform, realname, realname_os, username,
-        username_os,
+        distro, hostname, lang_prefs, platform, realname, realname_os,
+        username, username_os,
     },
     arch::{Arch, Width},
     desktop_env::DesktopEnv,
-    language::{Country, Language},
+    language::{Country, Language, LanguagePrefs},
     platform::Platform,
     result::Result,
 };

--- a/src/os.rs
+++ b/src/os.rs
@@ -52,7 +52,7 @@ use std::{
     io::{Error, ErrorKind},
 };
 
-use crate::{Arch, DesktopEnv, Platform, Result};
+use crate::{Arch, DesktopEnv, Language, LanguagePrefs, Platform, Result};
 
 /// Implement `Target for Os` to add platform support for a target.
 pub(crate) struct Os;
@@ -60,7 +60,7 @@ pub(crate) struct Os;
 /// Target platform support
 pub(crate) trait Target: Sized {
     /// Return a semicolon-delimited string of language/COUNTRY codes.
-    fn langs(self) -> Result<String>;
+    fn lang_prefs(self) -> Result<LanguagePrefs>;
     /// Return the user's "real" / "full" name.
     fn realname(self) -> Result<OsString>;
     /// Return the user's username.
@@ -105,32 +105,57 @@ fn err_empty_record() -> Error {
 
 // This is only used on some platforms
 #[allow(dead_code)]
-fn unix_lang() -> Result<String> {
-    let check_var = |var| {
-        env::var(var).map_err(|e| {
-            let kind = match e {
-                VarError::NotPresent => ErrorKind::NotFound,
-                VarError::NotUnicode(_) => ErrorKind::InvalidData,
-            };
-            Error::new(kind, e)
-        })
+fn unix_lang() -> Result<LanguagePrefs> {
+    let env_var = |var: &str| match env::var(var) {
+        Ok(value) => Ok(if value.is_empty() { None } else { Some(value) }),
+        Err(VarError::NotPresent) => Ok(None),
+        Err(VarError::NotUnicode(_)) => Err(ErrorKind::InvalidData),
     };
 
     // Uses priority defined in
     // <https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html>
-    let locale = check_var("LC_ALL").or_else(|_| check_var("LANG"));
+    let lc_all = env_var("LC_ALL")?;
+    let lang = env_var("LANG")?;
 
-    // The LANGUAGE environment variable takes precedence if and only if
-    // localization is enabled, i.e., LC_ALL / LANG is not "C".
-    // <https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html>
-    let langs = match &locale {
-        Ok(loc) if loc != "C" => check_var("LANGUAGE").or(locale),
-        _ => locale,
-    }?;
-
-    if langs.is_empty() {
+    if lang.is_none() && lc_all.is_none() {
         return Err(err_empty_record());
     }
 
-    Ok(langs)
+    // Standard locales that have a higher global precedence than their specific
+    // counterparts, indicating that one should not perform any localization.
+    // https://www.gnu.org/software/libc/manual/html_node/Standard-Locales.html
+    if let Some(l) = &lang {
+        if l == "C" || l == "POSIX" {
+            return Ok(LanguagePrefs {
+                fallbacks: Vec::new(),
+                ..Default::default()
+            });
+        }
+    }
+
+    // The LANGUAGE environment variable takes precedence if and only if
+    // localization is enabled, i.e., LC_ALL / LANG is not "C" or "POSIX".
+    // <https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html>
+    if let Some(language) = env_var("LANGUAGE")? {
+        return Ok(LanguagePrefs {
+            fallbacks: language.split(":").map(Language::from).collect(),
+            ..Default::default()
+        });
+    }
+
+    // All fields other than LANGUAGE can only contain a single value, so we
+    // don't need to perform any splitting at this point.
+    let lang_from_var = |var| -> Result<Option<Language>, Error> {
+        Ok(env_var(var)?.map(Language::from))
+    };
+
+    Ok(LanguagePrefs {
+        fallbacks: lang.map_or_else(Vec::new, |l| [Language::from(l)].to_vec()),
+        collation: lang_from_var("LC_COLLATE")?,
+        char_classes: lang_from_var("LC_CTYPE")?,
+        monetary: lang_from_var("LC_MONTEARY")?,
+        messages: lang_from_var("LC_MESSAGES")?,
+        numeric: lang_from_var("LC_NUMERIC")?,
+        time: lang_from_var("LC_TIME")?,
+    })
 }

--- a/src/os/daku.rs
+++ b/src/os/daku.rs
@@ -7,13 +7,16 @@ use std::{
 
 use crate::{
     os::{Os, Target},
-    Arch, DesktopEnv, Platform, Result,
+    Arch, DesktopEnv, Language, LanguagePrefs, Platform, Result,
 };
 
 impl Target for Os {
     #[inline(always)]
-    fn langs(self) -> Result<String> {
-        Ok("en/US".to_string())
+    fn lang_prefs(self) -> Result<LanguagePrefs> {
+        Ok(LanguagePrefs {
+            fallbacks: [Language::from("en/US")].to_vec(),
+            ..Default::default()
+        })
     }
 
     #[inline(always)]

--- a/src/os/redox.rs
+++ b/src/os/redox.rs
@@ -7,7 +7,7 @@ use syscall::{call, error};
 
 use crate::{
     os::{Os, Target},
-    Arch, DesktopEnv, Platform, Result,
+    Arch, DesktopEnv, LanguagePrefs, Platform, Result,
 };
 
 /// Row in the Redox /etc/passwd file
@@ -88,7 +88,7 @@ fn hostname() -> Result<String> {
 }
 
 impl Target for Os {
-    fn langs(self) -> Result<String> {
+    fn lang_prefs(self) -> Result<LanguagePrefs> {
         super::unix_lang()
     }
 

--- a/src/os/target.rs
+++ b/src/os/target.rs
@@ -9,13 +9,16 @@ use std::{
 
 use crate::{
     os::{Os, Target},
-    Arch, DesktopEnv, Platform, Result,
+    Arch, DesktopEnv, Language, LanguagePrefs, Platform, Result,
 };
 
 impl Target for Os {
     #[inline(always)]
-    fn langs(self) -> Result<String> {
-        Ok("en/US".to_string())
+    fn lang_prefs(self) -> Result<LanguagePrefs> {
+        Ok(LanguagePrefs {
+            fallbacks: [Language::from("en/US")].to_vec(),
+            ..Default::default()
+        })
     }
 
     #[inline(always)]

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -25,7 +25,7 @@ use std::{
 
 use crate::{
     os::{Os, Target},
-    Arch, DesktopEnv, Platform, Result,
+    Arch, DesktopEnv, LanguagePrefs, Platform, Result,
 };
 
 #[cfg(any(target_os = "linux", target_os = "hurd"))]
@@ -443,7 +443,7 @@ unsafe fn uname(buf: *mut UtsName) -> c_int {
 }
 
 impl Target for Os {
-    fn langs(self) -> Result<String> {
+    fn lang_prefs(self) -> Result<LanguagePrefs> {
         super::unix_lang()
     }
 

--- a/src/os/wasi.rs
+++ b/src/os/wasi.rs
@@ -5,11 +5,11 @@ use std::{env, ffi::OsString};
 
 use crate::{
     os::{Os, Target},
-    Arch, DesktopEnv, Platform, Result,
+    Arch, DesktopEnv, LanguagePrefs, Platform, Result,
 };
 
 impl Target for Os {
-    fn langs(self) -> Result<String> {
+    fn lang_prefs(self) -> Result<LanguagePrefs> {
         super::unix_lang()
     }
 

--- a/src/os/web.rs
+++ b/src/os/web.rs
@@ -10,7 +10,7 @@ use web_sys::window;
 
 use crate::{
     os::{Os, Target},
-    Arch, DesktopEnv, Platform, Result,
+    Arch, DesktopEnv, Language, LanguagePrefs, Platform, Result,
 };
 
 // Get the user agent
@@ -24,16 +24,19 @@ fn document_domain() -> Option<String> {
 }
 
 impl Target for Os {
-    fn langs(self) -> Result<String> {
+    fn lang_prefs(self) -> Result<LanguagePrefs> {
         if let Some(window) = window() {
-            Ok(window
+            let langs = window
                 .navigator()
                 .languages()
                 .to_vec()
                 .into_iter()
-                .filter_map(|l| l.as_string())
-                .collect::<Vec<String>>()
-                .join(";"))
+                .filter_map(|l| l.as_string().map(Language::from))
+                .collect::<Vec<_>>();
+            Ok(LanguagePrefs {
+                fallbacks: langs,
+                ..Default::default()
+            })
         } else {
             Err(Error::new(
                 ErrorKind::NotFound,

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -9,7 +9,7 @@ use std::{
 use crate::{
     conversions,
     os::{Os, Target},
-    Arch, DesktopEnv, Platform, Result,
+    Arch, DesktopEnv, Language, LanguagePrefs, Platform, Result,
 };
 
 #[repr(C)]
@@ -176,7 +176,7 @@ fn extended_name(format: ExtendedNameFormat) -> Result<OsString> {
 
 impl Target for Os {
     #[inline(always)]
-    fn langs(self) -> Result<String> {
+    fn lang_prefs(self) -> Result<LanguagePrefs> {
         let mut num_languages = 0;
         let mut buffer_size = 0;
         let mut buffer;
@@ -212,10 +212,13 @@ impl Target for Os {
         buffer.pop();
 
         // Combine into a single string
-        Ok(String::from_utf16_lossy(&buffer)
-            .split('\0')
-            .collect::<Vec<&str>>()
-            .join(";"))
+        Ok(LanguagePrefs {
+            fallbacks: String::from_utf16_lossy(&buffer)
+                .split('\0')
+                .map(Language::from)
+                .collect::<Vec<Language>>(),
+            ..Default::default()
+        })
     }
 
     fn realname(self) -> Result<OsString> {


### PR DESCRIPTION
Adds a new `lang_category` function which accepts the POSIX standard locale category values. Each value is checked in priority order as:

1. `LC_ALL`
2. `LC_xxx`
3. `LANG`

Closes #145