### PR TITLE
Fix `LanguagePrefs` impl of `Display`

### DIFF
--- a/src/language.rs
+++ b/src/language.rs
@@ -153,7 +153,7 @@ impl Display for LanguagePrefs {
             if i != 0 {
                 f.write_str(",")?;
             }
-            f.write_str(name)?;
+            write!(f, "{}=", name)?;
             for (j, lang) in langs.iter().enumerate() {
                 if j != 0 {
                     f.write_str(":")?;


### PR DESCRIPTION
Fixes a mistake in the implementation of the `Display` trait for `LanguagePrefs` which output:

```diff
- Collationen/US,...
+ Collation=en/US,...
```