### PR TITLE
Eliminate critical code duplication in Windows & Unix modules

### DIFF
--- a/whoami/src/os/unix.rs
+++ b/whoami/src/os/unix.rs
@@ -161,14 +161,21 @@ unsafe fn strlen_gecos(cs: *const c_void) -> usize {
     len
 }
 
-fn os_from_cstring_gecos(string: *const c_void) -> Result<OsString> {
+/// Helper function to convert C string to OsString using a custom strlen function
+fn os_from_cstring_impl<F>(
+    string: *const c_void,
+    strlen_fn: F,
+) -> Result<OsString>
+where
+    F: Fn(*const c_void) -> usize,
+{
     if string.is_null() {
         return Err(super::err_null_record());
     }
 
     // Get a byte slice of the c string.
     let slice = unsafe {
-        let length = strlen_gecos(string);
+        let length = strlen_fn(string);
 
         if length == 0 {
             return Err(super::err_empty_record());
@@ -181,24 +188,12 @@ fn os_from_cstring_gecos(string: *const c_void) -> Result<OsString> {
     Ok(OsString::from_vec(slice.to_vec()))
 }
 
+fn os_from_cstring_gecos(string: *const c_void) -> Result<OsString> {
+    os_from_cstring_impl(string, |s| unsafe { strlen_gecos(s) })
+}
+
 fn os_from_cstring(string: *const c_void) -> Result<OsString> {
-    if string.is_null() {
-        return Err(super::err_null_record());
-    }
-
-    // Get a byte slice of the c string.
-    let slice = unsafe {
-        let length = strlen(string);
-
-        if length == 0 {
-            return Err(super::err_empty_record());
-        }
-
-        slice::from_raw_parts(string.cast(), length)
-    };
-
-    // Turn byte slice into Rust String.
-    Ok(OsString::from_vec(slice.to_vec()))
+    os_from_cstring_impl(string, |s| unsafe { strlen(s) })
 }
 
 #[cfg(target_os = "macos")]

--- a/whoami/src/os/windows.rs
+++ b/whoami/src/os/windows.rs
@@ -64,6 +64,7 @@ enum ExtendedNameFormat {
 
 #[allow(unused)]
 #[repr(C)]
+#[derive(Copy, Clone)]
 enum ComputerNameFormat {
     NetBIOS,                   // All caps hostname
     DnsHostname,               // Hostname
@@ -178,6 +179,39 @@ fn extended_name(format: ExtendedNameFormat) -> Result<OsString> {
     Ok(OsString::from_wide(&name))
 }
 
+/// Helper function to retrieve computer name using GetComputerNameExW
+fn get_computer_name(format: ComputerNameFormat) -> Result<Vec<u16>> {
+    // Step 1. Retrieve the entire length of the computer name
+    let mut size = 0;
+    let fail = unsafe {
+        // Ignore error, we know that it will be ERROR_INSUFFICIENT_BUFFER
+        GetComputerNameExW(format, ptr::null_mut(), &mut size) == 0
+    };
+
+    assert!(fail);
+
+    if Error::last_os_error().raw_os_error() != Some(ERR_MORE_DATA) {
+        return Err(Error::last_os_error());
+    }
+
+    // Step 2. Allocate memory to put the Windows (UTF-16) string.
+    let mut name: Vec<u16> =
+        Vec::with_capacity(size.try_into().unwrap_or(usize::MAX));
+    let mut size = name.capacity().try_into().unwrap_or(u32::MAX);
+
+    if unsafe {
+        GetComputerNameExW(format, name.as_mut_ptr().cast(), &mut size) == 0
+    } {
+        return Err(Error::last_os_error());
+    }
+
+    unsafe {
+        name.set_len(size.try_into().unwrap_or(usize::MAX));
+    }
+
+    Ok(name)
+}
+
 impl Target for Os {
     #[inline(always)]
     fn lang_prefs(self) -> Result<LanguagePrefs> {
@@ -234,85 +268,19 @@ impl Target for Os {
     }
 
     fn devicename(self) -> Result<OsString> {
-        // Step 1. Retreive the entire length of the device name
-        let mut size = 0;
-        let fail = unsafe {
-            // Ignore error, we know that it will be ERROR_INSUFFICIENT_BUFFER
-            GetComputerNameExW(
-                ComputerNameFormat::DnsHostname,
-                ptr::null_mut(),
-                &mut size,
-            ) == 0
-        };
-
-        assert!(fail);
-
-        if Error::last_os_error().raw_os_error() != Some(ERR_MORE_DATA) {
-            return Err(Error::last_os_error());
-        }
-
-        // Step 2. Allocate memory to put the Windows (UTF-16) string.
-        let mut name: Vec<u16> =
-            Vec::with_capacity(size.try_into().unwrap_or(usize::MAX));
-        let mut size = name.capacity().try_into().unwrap_or(u32::MAX);
-
-        if unsafe {
-            GetComputerNameExW(
-                ComputerNameFormat::DnsHostname,
-                name.as_mut_ptr().cast(),
-                &mut size,
-            ) == 0
-        } {
-            return Err(Error::last_os_error());
-        }
-
-        unsafe {
-            name.set_len(size.try_into().unwrap_or(usize::MAX));
-        }
-
-        // Step 3. Convert to Rust String
-        Ok(OsString::from_wide(&name))
+        get_computer_name(ComputerNameFormat::DnsHostname).map(|s| {
+            let mut name = s;
+            unsafe {
+                name.set_len(name.len().saturating_sub(1));
+            }
+            OsString::from_wide(&name)
+        })
     }
 
     fn hostname(self) -> Result<String> {
-        // Step 1. Retreive the entire length of the username
-        let mut size = 0;
-        let fail = unsafe {
-            // Ignore error, we know that it will be ERROR_INSUFFICIENT_BUFFER
-            GetComputerNameExW(
-                ComputerNameFormat::PhysicalDnsHostname,
-                ptr::null_mut(),
-                &mut size,
-            ) == 0
-        };
-
-        assert!(fail);
-
-        if Error::last_os_error().raw_os_error() != Some(ERR_MORE_DATA) {
-            return Err(Error::last_os_error());
-        }
-
-        // Step 2. Allocate memory to put the Windows (UTF-16) string.
-        let mut name: Vec<u16> =
-            Vec::with_capacity(size.try_into().unwrap_or(usize::MAX));
-        let mut size = name.capacity().try_into().unwrap_or(u32::MAX);
-
-        if unsafe {
-            GetComputerNameExW(
-                ComputerNameFormat::PhysicalDnsHostname,
-                name.as_mut_ptr().cast(),
-                &mut size,
-            ) == 0
-        } {
-            return Err(Error::last_os_error());
-        }
-
-        unsafe {
-            name.set_len(size.try_into().unwrap_or(usize::MAX));
-        }
-
-        // Step 3. Convert to Rust String
-        conversions::string_from_os(OsString::from_wide(&name))
+        get_computer_name(ComputerNameFormat::PhysicalDnsHostname).and_then(
+            |name| conversions::string_from_os(OsString::from_wide(&name)),
+        )
     }
 
     fn distro(self) -> Result<String> {


### PR DESCRIPTION
i found and fixed some exact duplicates. Extracted shared logic into helper functions  `get_computer_name()` for Windows API calls and `os_from_cstring_impl()` for Unix C strings. 
