### PR TITLE
Add some `must_use`s, organize attributes, remove redundant `non_exhaustive`, fix small copypaste bug (Wasm64)

### DIFF
--- a/whoami/src/api.rs
+++ b/whoami/src/api.rs
@@ -15,6 +15,7 @@ macro_rules! report_message {
 }
 
 /// Get the CPU Architecture.
+#[must_use]
 #[inline(always)]
 pub fn cpu_arch() -> CpuArchitecture {
     Target::arch(Os).expect(concat!("arch() failed.  ", report_message!()))
@@ -154,6 +155,7 @@ pub fn distro() -> Result<String> {
 ///
 /// Returns `None` if a desktop environment is not available (for example in a
 /// TTY or over SSH)
+#[must_use]
 #[inline(always)]
 pub fn desktop_env() -> Option<DesktopEnvironment> {
     #[cfg(feature = "std")]
@@ -170,6 +172,7 @@ pub fn desktop_env() -> Option<DesktopEnvironment> {
 }
 
 /// Get the platform.
+#[must_use]
 #[inline(always)]
 pub fn platform() -> Platform {
     Target::platform(Os)

--- a/whoami/src/arch.rs
+++ b/whoami/src/arch.rs
@@ -23,8 +23,8 @@ impl Display for Width {
 }
 
 /// The architecture of a CPU
-#[non_exhaustive]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum CpuArchitecture {
     /// Unknown Architecture
     Unknown(String),

--- a/whoami/src/cpu_arch.rs
+++ b/whoami/src/cpu_arch.rs
@@ -23,8 +23,8 @@ impl Display for Width {
 }
 
 /// The architecture of a CPU
-#[non_exhaustive]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
 pub enum CpuArchitecture {
     /// Other Architecture
     Other(String),

--- a/whoami/src/desktop_env.rs
+++ b/whoami/src/desktop_env.rs
@@ -9,6 +9,8 @@ use std::{
 pub enum DesktopEnvironment {
     /// Unknown desktop environment
     Unknown(String),
+    /// Running as Web Assembly on a web page
+    WebBrowser(String),
     /// Popular GTK-based desktop environment on Linux
     Gnome,
     /// One of the desktop environments for a specific version of Windows
@@ -33,8 +35,6 @@ pub enum DesktopEnvironment {
     Ios,
     /// Desktop environment for Android
     Android,
-    /// Running as Web Assembly on a web page
-    WebBrowser(String),
     /// A desktop environment for a video game console
     Console,
     /// Ubuntu-branded GNOME
@@ -52,7 +52,8 @@ impl Display for DesktopEnvironment {
         }
 
         f.write_str(match self {
-            Self::Unknown(a) => a,
+            Self::Unknown(de) => de,
+            Self::WebBrowser(de) => return write!(f, "WebBrowser ({de})"),
             Self::Gnome => "Gnome",
             Self::Windows => "Windows",
             Self::Lxde => "LXDE",
@@ -65,7 +66,6 @@ impl Display for DesktopEnvironment {
             Self::Aqua => "Aqua",
             Self::Ios => "IOS",
             Self::Android => "Android",
-            Self::WebBrowser(a) => return write!(f, "WebBrowser ({a})"),
             Self::Console => "Console",
             Self::Ubuntu => "Ubuntu",
             Self::Ermine => "Ermine",
@@ -76,17 +76,22 @@ impl Display for DesktopEnvironment {
 
 impl DesktopEnvironment {
     /// Returns true if the desktop environment is based on GTK.
-    pub fn is_gtk(&self) -> bool {
-        *self == Self::Gnome
-            || *self == Self::Ubuntu
-            || *self == Self::Cinnamon
-            || *self == Self::Lxde
-            || *self == Self::Mate
-            || *self == Self::Xfce
+    #[must_use]
+    pub const fn is_gtk(&self) -> bool {
+        matches!(
+            self,
+            Self::Gnome
+                | Self::Ubuntu
+                | Self::Cinnamon
+                | Self::Lxde
+                | Self::Mate
+                | Self::Xfce
+        )
     }
 
     /// Returns true if the desktop environment is based on KDE.
-    pub fn is_kde(&self) -> bool {
-        *self == Self::Plasma
+    #[must_use]
+    pub const fn is_kde(&self) -> bool {
+        matches!(self, Self::Plasma)
     }
 }

--- a/whoami/src/error.rs
+++ b/whoami/src/error.rs
@@ -7,7 +7,6 @@ use std::io::Error as IoError;
 struct IoError(Cow<'static, str>);
 
 /// An I/O error; can be converted to [`std::io::Error`].
-#[non_exhaustive]
 #[derive(Debug)]
 pub struct Error(IoError);
 

--- a/whoami/src/lang_prefs.rs
+++ b/whoami/src/lang_prefs.rs
@@ -30,7 +30,6 @@ use crate::{Error, Result};
 /// `-`, `_`, or `/`).
 ///
 /// [`ToString::to_string()`]: std::string::ToString::to_string
-#[non_exhaustive]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct Language {
     /// The language code for this language
@@ -45,7 +44,8 @@ pub struct Language {
 
 impl Default for Language {
     fn default() -> Self {
-        Self::from_str("en/US").expect("this is a bug; failed to parse en/US")
+        Self::from_str("en/US")
+            .expect("this is an internal bug (failed to parse en/US)")
     }
 }
 
@@ -209,7 +209,6 @@ impl PartialEq<&str> for Language {
 /// <https://man7.org/linux/man-pages/man7/locale.7.html>. Windows locale values
 /// are defined in <https://learn.microsoft.com/en-us/cpp/c-runtime-library/locale-categories>.
 #[derive(Debug, Clone, Default)]
-#[non_exhaustive]
 pub struct LanguagePreferences {
     /// Determines general user language preference, should be used in
     /// situations which are not encompassed by other [`LanguagePreferences`].

--- a/whoami/src/os/stub.rs
+++ b/whoami/src/os/stub.rs
@@ -22,22 +22,22 @@ impl Target for Os {
 
     #[inline(always)]
     fn realname(self) -> Result<OsString> {
-        Ok("Anonymous".to_string().into())
+        Ok(OsString::from("Anonymous"))
     }
 
     #[inline(always)]
     fn username(self) -> Result<OsString> {
-        Ok("anonymous".to_string().into())
+        Ok(OsString::from("anonymous"))
     }
 
     #[inline(always)]
     fn devicename(self) -> Result<OsString> {
-        Ok("Unknown".to_string().into())
+        Ok(OsString::from("Unknown"))
     }
 
     #[inline(always)]
     fn hostname(self) -> Result<String> {
-        Ok("localhost".to_string())
+        Ok(String::from("localhost"))
     }
 
     #[inline(always)]
@@ -114,7 +114,7 @@ impl Target for Os {
     fn arch(self) -> Result<CpuArchitecture> {
         #[cfg(target_pointer_width = "32")]
         {
-            Ok(CpuArchitecture::Wasm64)
+            Ok(CpuArchitecture::Wasm32)
         }
 
         #[cfg(target_pointer_width = "64")]


### PR DESCRIPTION
Changes:
* Added `#[must_use]` attributes to "pure" functions with no side effects (except potential panicking)
* Removed some redundant `#[non_exhaustive]`: This  attribute has no effect on structs with at least one private field
* Slightly organized some attributes (`derive` should probably come first)
* Rewrote the `DesktopEnvironment::is_gtk` method (uses `matches!` now)
* Made the `DesktopEnvironment::is_gtk` and `DesktopEnvironment::is_kde` methods const. I can undo this if you need future compatibility with non-constness
* Probably fixed a small copypaste bug in `stub.rs`: `target_pointer_width` now properly matches the `CpuArchitecture`

## Testing / Verification
It compiles, `cargo run` behaves normally and all tests (`cargo test`) pass.