### PR TITLE
Restore MSRV support and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
     - uses: taiki-e/checkout-action@v1
     - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
-    - run: rustup toolchain install ${{ matrix.tc }}
+    - run: rustup default ${{ matrix.tc }}
+    - run: rustup component add rustfmt clippy
     - run: cargo update
     - run: cargo fmt --check
     - run: cargo clippy -- -D warnings
@@ -37,7 +38,8 @@ jobs:
     - uses: taiki-e/checkout-action@v1
     - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
-    - run: rustup toolchain install ${{ matrix.tc }}
+    - run: rustup default ${{ matrix.tc }}
+    - run: rustup component add clippy
     - run: rustup target add ${{ matrix.cc }}
     - run: cargo update
     - run: cargo clippy --target=${{ matrix.cc }} -- -D warnings
@@ -52,7 +54,8 @@ jobs:
     - uses: taiki-e/checkout-action@v1
     - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
-    - run: rustup toolchain install ${{ matrix.tc }}
+    - run: rustup default ${{ matrix.tc }}
+    - run: rustup component add clippy
     - run: rustup target add ${{ matrix.cc }}
     - run: cargo clippy --target=${{ matrix.cc }} -- -D warnings
   checks-cross-compile-wasm:
@@ -66,7 +69,8 @@ jobs:
     - uses: taiki-e/checkout-action@v1
     - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
-    - run: rustup toolchain install ${{ matrix.tc }}
+    - run: rustup default ${{ matrix.tc }}
+    - run: rustup component add clippy
     - run: rustup target add ${{ matrix.cc }}
     - run: cargo clippy --target=${{ matrix.cc }} -- -D warnings
     - run: cargo update
@@ -82,7 +86,7 @@ jobs:
     - uses: taiki-e/checkout-action@v1
     - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
-    - run: rustup toolchain install ${{ matrix.tc }}
+    - run: rustup default ${{ matrix.tc }}
     - run: cargo doc
     - run: cargo test --all
   cross-compile:
@@ -102,7 +106,7 @@ jobs:
     - uses: taiki-e/checkout-action@v1
     - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
-    - run: rustup toolchain install ${{ matrix.tc }}
+    - run: rustup default ${{ matrix.tc }}
     - run: rustup target add ${{ matrix.cc }}
     - run: cargo build --target=${{ matrix.cc }} -p whoami
   cross-compile-ios:
@@ -116,7 +120,7 @@ jobs:
     - uses: taiki-e/checkout-action@v1
     - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
-    - run: rustup toolchain install ${{ matrix.tc }}
+    - run: rustup default ${{ matrix.tc }}
     - run: rustup target add ${{ matrix.cc }}
     - run: cargo build --target=${{ matrix.cc }}
   cross-compile-wasm:
@@ -130,7 +134,7 @@ jobs:
     - uses: taiki-e/checkout-action@v1
     - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
-    - run: rustup toolchain install ${{ matrix.tc }}
+    - run: rustup default ${{ matrix.tc }}
     - run: rustup target add ${{ matrix.cc }}
     - run: cargo build --target=${{ matrix.cc }}
     - run: cargo update
@@ -147,7 +151,7 @@ jobs:
     - uses: taiki-e/checkout-action@v1
     - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
-    - run: rustup toolchain install ${{ matrix.tc }}
+    - run: rustup default ${{ matrix.tc }}
     - run: rustup target add ${{ matrix.cc }}
     - run: cargo build --target=${{ matrix.cc }} -p whoami
   cross-compile-redox:
@@ -161,7 +165,7 @@ jobs:
     - uses: taiki-e/checkout-action@v1
     - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
-    - run: rustup toolchain install ${{ matrix.tc }}
+    - run: rustup default ${{ matrix.tc }}
     - run: rustup target add ${{ matrix.cc }}
     - run: cargo build --target=${{ matrix.cc }} -p whoami
   clippy-cross-compile:
@@ -177,6 +181,7 @@ jobs:
     - uses: taiki-e/checkout-action@v1
     - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
-    - run: rustup toolchain install ${{ matrix.tc }}
+    - run: rustup default ${{ matrix.tc }}
+    - run: rustup component add clippy
     - run: rustup target add ${{ matrix.cc }}
     - run: cargo clippy --target=${{ matrix.cc }} -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,13 @@ jobs:
         - i686-unknown-linux-gnu
         - wasm32-wasip1
         - x86_64-apple-darwin
+        exclude:
+        - tc: 1.65.0
+          cc: wasm32-wasip1
+        include:
+        - os: ubuntu-latest
+          tc: 1.65.0
+          cc: wasm32-wasi
     steps:
     - uses: taiki-e/checkout-action@v1
     - uses: taiki-e/install-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
         tc: [nightly]
     steps:
     - uses: taiki-e/checkout-action@v1
-    - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
     - run: rustup default ${{ matrix.tc }}
     - run: rustup component add rustfmt clippy
@@ -36,7 +35,6 @@ jobs:
         - x86_64-apple-darwin
     steps:
     - uses: taiki-e/checkout-action@v1
-    - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
     - run: rustup default ${{ matrix.tc }}
     - run: rustup component add clippy
@@ -52,7 +50,6 @@ jobs:
         cc: [aarch64-apple-ios]
     steps:
     - uses: taiki-e/checkout-action@v1
-    - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
     - run: rustup default ${{ matrix.tc }}
     - run: rustup component add clippy
@@ -67,7 +64,6 @@ jobs:
         cc: [wasm32-unknown-unknown]
     steps:
     - uses: taiki-e/checkout-action@v1
-    - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
     - run: rustup default ${{ matrix.tc }}
     - run: rustup component add clippy
@@ -84,7 +80,6 @@ jobs:
         tc: [1.65.0, stable, beta, nightly]
     steps:
     - uses: taiki-e/checkout-action@v1
-    - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
     - run: rustup default ${{ matrix.tc }}
     - run: cargo doc
@@ -111,7 +106,6 @@ jobs:
           cc: wasm32-wasi
     steps:
     - uses: taiki-e/checkout-action@v1
-    - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
     - run: rustup default ${{ matrix.tc }}
     - run: rustup target add ${{ matrix.cc }}
@@ -125,7 +119,6 @@ jobs:
         cc: [aarch64-apple-ios]
     steps:
     - uses: taiki-e/checkout-action@v1
-    - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
     - run: rustup default ${{ matrix.tc }}
     - run: rustup target add ${{ matrix.cc }}
@@ -139,7 +132,6 @@ jobs:
         cc: [wasm32-unknown-unknown]
     steps:
     - uses: taiki-e/checkout-action@v1
-    - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
     - run: rustup default ${{ matrix.tc }}
     - run: rustup target add ${{ matrix.cc }}
@@ -156,7 +148,6 @@ jobs:
         cc: [x86_64-unknown-illumos]
     steps:
     - uses: taiki-e/checkout-action@v1
-    - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
     - run: rustup default ${{ matrix.tc }}
     - run: rustup target add ${{ matrix.cc }}
@@ -170,7 +161,6 @@ jobs:
         cc: [x86_64-unknown-redox]
     steps:
     - uses: taiki-e/checkout-action@v1
-    - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
     - run: rustup default ${{ matrix.tc }}
     - run: rustup target add ${{ matrix.cc }}
@@ -186,7 +176,6 @@ jobs:
         - x86_64-unknown-redox
     steps:
     - uses: taiki-e/checkout-action@v1
-    - uses: taiki-e/install-action@v2
     - run: rustup set profile minimal
     - run: rustup default ${{ matrix.tc }}
     - run: rustup component add clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
-resolver = "3"
+# FIXME: bump to `3` with MSRV >=1.84
+resolver = "2"
 members = ["example-web", "whoami", "xtask"]
 exclude = ["build"]
 

--- a/example-web/Cargo.toml
+++ b/example-web/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "whoami_web"
-edition = "2024"
+version = "0.0.0"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/whoami/src/error.rs
+++ b/whoami/src/error.rs
@@ -16,6 +16,9 @@ impl core::fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+#[cfg(not(feature = "std"))]
 impl core::error::Error for Error {}
 
 #[allow(dead_code)]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "xtask"
-edition = "2024"
+version = "0.0.0"
+edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Fixes #203
Caused by #181

The last remaining issue is that this crate can't work with v1.65 because #200 changed the implementation of `whoami::Error` from `std::error::Error` to `core::error::Error`, which is only available starting from v1.81.

## Testing / Verification

Done by CI and locally with `cargo +1.65 check`
