### PR TITLE
Fix typo in `LC_MONETARY` env var name

### DIFF
--- a/whoami/src/os.rs
+++ b/whoami/src/os.rs
@@ -179,7 +179,7 @@ fn unix_lang() -> Result<LanguagePreferences> {
             .unwrap_or(Vec::new()),
         collation: lang_from_var("LC_COLLATE")?,
         char_classes: lang_from_var("LC_CTYPE")?,
-        monetary: lang_from_var("LC_MONTEARY")?,
+        monetary: lang_from_var("LC_MONETARY")?,
         messages: lang_from_var("LC_MESSAGES")?,
         numeric: lang_from_var("LC_NUMERIC")?,
         time: lang_from_var("LC_TIME")?,


### PR DESCRIPTION
This fixes a typo I happened to find in the code.
Introduced in #155.

## Testing / Verification

I'm don't know how to test this.