### PR TITLE
Fix architecture detection bug in Daku OS

### DIFF
--- a/whoami/src/os/daku.rs
+++ b/whoami/src/os/daku.rs
@@ -56,7 +56,7 @@ impl Target for Os {
     fn arch(self) -> Result<CpuArchitecture> {
         #[cfg(target_pointer_width = "32")]
         {
-            Ok(CpuArchitecture::Wasm64)
+            Ok(CpuArchitecture::Wasm32)
         }
 
         #[cfg(target_pointer_width = "64")]


### PR DESCRIPTION
This fixes an architecture detection bug in Daku.
Introduced in #200.

## Testing / Verification

None.
