### PR TITLE
Fix recursive Display implementation in Error type

### DIFF
--- a/whoami/src/error.rs
+++ b/whoami/src/error.rs
@@ -12,7 +12,7 @@ pub struct Error(IoError);
 
 impl core::fmt::Display for Error {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Display::fmt(&self, f)
+        core::fmt::Display::fmt(&self.0, f)
     }
 }
 


### PR DESCRIPTION
Calling `.to_string()` on `Error` lead to infinite recursion.
Introduced in #200.

## Testing / Verification

Tested manually.
