### PR TITLE
Prepare v2.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,6 @@ jobs:
     - run: rustup default ${{ matrix.tc }}
     - run: rustup target add ${{ matrix.cc }}
     - run: cargo build --target=${{ matrix.cc }}
-    - run: cargo update
     - run: cargo build --no-default-features --target=${{ matrix.cc }}
     - run: RUSTFLAGS="--cfg daku" cargo build --target=${{ matrix.cc }}
   cross-compile-illumos:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "libredox",
  "wasite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,18 +105,19 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "wasi"
-version = "0.14.0+wasi-0.2.3"
+version = "0.13.0+wasi-0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d67b0bdfec72b9fbaba698033291c327ef19ce3b34efbdcd7dc402a53850d9"
+checksum = "652cd73449d0b957a2743b70c72d79d34a5fa505696488f4ca90b46f6da94118"
 dependencies = [
+ "bitflags",
  "wit-bindgen-rt",
 ]
 
 [[package]]
 name = "wasite"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313fb64fed616e75426cf738284efe4e85017243bccfae42698be1d7fa9b05d5"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
 dependencies = [
  "wasi",
 ]
@@ -197,12 +198,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.37.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc801b991c56492f87ab3086e786468f75c285a4d73017ab0ebc2fa1aed5d82c"
-dependencies = [
- "bitflags",
-]
+checksum = "026d24a27f6712541fa534f2954bd9e0eb66172f033c2157c0f31d106255c497"
 
 [[package]]
 name = "xtask"

--- a/example-web/Cargo.toml
+++ b/example-web/Cargo.toml
@@ -2,6 +2,7 @@
 name = "whoami_web"
 version = "0.0.0"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/whoami/Cargo.toml
+++ b/whoami/Cargo.toml
@@ -33,7 +33,7 @@ default-features = false
 
 # Target-specific dependency for wasite
 [target.'cfg(all(target_arch = "wasm32", target_os = "wasi"))'.dependencies.wasite]
-version = "1.0.1"
+version = "1.0.2"
 optional = true
 default-features = false
 

--- a/whoami/Cargo.toml
+++ b/whoami/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whoami"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 license = "Apache-2.0 OR BSL-1.0 OR MIT"
 documentation = "https://docs.rs/whoami"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "xtask"
 version = "0.0.0"
+publish = false
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
# Fixed 

 - MSRV testing in CI actually works again
 - MSRV mishap - WhoAmI 2.0.0 was requiring an MSRV of 1.81 accidentally, due to using `core::error::Error`, changed so that when the `std` feature is enabled the MSRV is as-advertised - 1.65.  Updated MSRV documentation to reflect that when the `std` feature is disabled it bumps the MSRV to 1.81
 - Fixed Daku reporting 64-bit when 32-bit in `cpu_arch()` implementation
 - Fixed environment variable typo `LC_MONTEARY` -> `LC_MONETARY`
 - Fixed `whoami::Error` having infinite recursion in the `Display` implementation
 - Fixed Broken links in the README.md
 - Updated wasite minimum version to v1.0.2 to fix MSRV issues on WASI