### PR TITLE
Add desktop environments: niri, hyprland and cosmic

### DIFF
--- a/whoami/src/desktop_env.rs
+++ b/whoami/src/desktop_env.rs
@@ -41,6 +41,8 @@ pub enum DesktopEnvironment {
     Ermine,
     /// Default desktop environment for Redox
     Orbital,
+    /// Wayland scrolling window manager for Linux
+    Niri,
 }
 
 impl Display for DesktopEnvironment {
@@ -68,6 +70,7 @@ impl Display for DesktopEnvironment {
             Self::Ubuntu => "Ubuntu",
             Self::Ermine => "Ermine",
             Self::Orbital => "Orbital",
+            Self::Niri => "Niri",
         })
     }
 }
@@ -84,6 +87,7 @@ impl DesktopEnvironment {
                 | Self::Lxde
                 | Self::Mate
                 | Self::Xfce
+                | Self::Niri
         )
     }
 

--- a/whoami/src/desktop_env.rs
+++ b/whoami/src/desktop_env.rs
@@ -43,6 +43,8 @@ pub enum DesktopEnvironment {
     Orbital,
     /// Wayland scrolling window manager for Linux
     Niri,
+    /// Wayland tiling window manager for Linux
+    Hyprland,
 }
 
 impl Display for DesktopEnvironment {
@@ -71,6 +73,7 @@ impl Display for DesktopEnvironment {
             Self::Ermine => "Ermine",
             Self::Orbital => "Orbital",
             Self::Niri => "Niri",
+            Self::Hyprland => "Hyprland",
         })
     }
 }

--- a/whoami/src/desktop_env.rs
+++ b/whoami/src/desktop_env.rs
@@ -45,6 +45,8 @@ pub enum DesktopEnvironment {
     Niri,
     /// Wayland tiling window manager for Linux
     Hyprland,
+    /// Rust based desktop environment on Linux
+    Cosmic,
 }
 
 impl Display for DesktopEnvironment {
@@ -74,6 +76,7 @@ impl Display for DesktopEnvironment {
             Self::Orbital => "Orbital",
             Self::Niri => "Niri",
             Self::Hyprland => "Hyprland",
+            Self::Cosmic => "Cosmic",
         })
     }
 }

--- a/whoami/src/os/unix.rs
+++ b/whoami/src/os/unix.rs
@@ -658,6 +658,8 @@ impl Target for Os {
             DesktopEnvironment::Niri
         } else if env.eq_ignore_ascii_case("HYPRLAND") {
             DesktopEnvironment::Hyprland
+        } else if env.eq_ignore_ascii_case("COSMIC") {
+            DesktopEnvironment::Cosmic
         } else {
             DesktopEnvironment::Unknown(env.to_string())
         })

--- a/whoami/src/os/unix.rs
+++ b/whoami/src/os/unix.rs
@@ -656,6 +656,8 @@ impl Target for Os {
             DesktopEnvironment::Xfce
         } else if env.eq_ignore_ascii_case("NIRI") {
             DesktopEnvironment::Niri
+        } else if env.eq_ignore_ascii_case("HYPRLAND") {
+            DesktopEnvironment::Hyprland
         } else {
             DesktopEnvironment::Unknown(env.to_string())
         })

--- a/whoami/src/os/unix.rs
+++ b/whoami/src/os/unix.rs
@@ -654,6 +654,8 @@ impl Target for Os {
             DesktopEnvironment::Plasma
         } else if env.eq_ignore_ascii_case("XFCE") {
             DesktopEnvironment::Xfce
+        } else if env.eq_ignore_ascii_case("NIRI") {
+            DesktopEnvironment::Niri
         } else {
             DesktopEnvironment::Unknown(env.to_string())
         })

--- a/whoami/src/os/unix.rs
+++ b/whoami/src/os/unix.rs
@@ -631,7 +631,9 @@ impl Target for Os {
             target_os = "illumos",
             target_os = "hurd",
         ))]
-        let env = env::var_os("DESKTOP_SESSION")?;
+        let env = env::var_os("XDG_SESSION_DESKTOP")
+            .or_else(|| env::var_os("DESKTOP_SESSION"))
+            .or_else(|| env::var_os("XDG_CURRENT_DESKTOP"))?;
 
         // convert `OsStr` to `Cow`
         let env = env.to_string_lossy();


### PR DESCRIPTION
Part of https://github.com/ardaku/whoami/issues/165

Thanks for making this crate. I noticed that there isn't support for a few Linux desktop environments I am familiar with. In my testing only checking the `DESKTOP_SESSION` environment variable was not sufficient. I've added fallbacks to `XDG_SESSION_DESKTOP` and `XDG_CURRENT_DESKTOP` in the order I think is most accurate.

I realise niri and hyprland are stretching the definition of desktop environment, since they are more accurately wayland compositors. If you feel these don't belong here then I'll happily drop the commits.

Thanks
