### PR TITLE
Fix missing license files in published crates

### DIFF
--- a/whoami/Cargo.toml
+++ b/whoami/Cargo.toml
@@ -17,9 +17,9 @@ categories = [
     "value-formatting",
 ]
 include = [
-    "../LICENSE_APACHE",
-    "../LICENSE_BOOST",
-    "../LICENSE_MIT",
+    "LICENSE_APACHE",
+    "LICENSE_BOOST",
+    "LICENSE_MIT",
     "../README.md",
     "/src/*",
 ]

--- a/whoami/LICENSE_APACHE
+++ b/whoami/LICENSE_APACHE
@@ -1,0 +1,1 @@
+../LICENSE_APACHE

--- a/whoami/LICENSE_BOOST
+++ b/whoami/LICENSE_BOOST
@@ -1,0 +1,1 @@
+../LICENSE_BOOST

--- a/whoami/LICENSE_MIT
+++ b/whoami/LICENSE_MIT
@@ -1,0 +1,1 @@
+../LICENSE_MIT


### PR DESCRIPTION
<!--- Please describe the changes in the PR and the motivation below -->
<!--- Check CONTRIBUTING.md for more information-->

Fixes missing license text files in the published crate by adding symbolic links to the top-level license files and adjusting the paths in `package.include`.

There was already an attempt to include these license files,

https://github.com/ardaku/whoami/blob/8ead5a943258073be2df085bea02c0957e4e04b7/whoami/Cargo.toml#L20-L23

and this approach worked for `README.md`, but it does not work for the license files.

If there is a possibility this crate may be published from Windows, then we could use copies of the license files instead of symlinks.

## Testing / Verification

<!-- Please describe any testing or verification done here -->
Before this PR:

```
$ cargo publish --dry-run
$ tar -tzvf ../target/package/whoami-2.0.2.crate
-rw-r--r-- 0/0             100 1970-01-01 01:00 whoami-2.0.2/.cargo_vcs_info.json
-rw-r--r-- 0/0            4763 1970-01-01 01:00 whoami-2.0.2/Cargo.lock
-rw-r--r-- 0/0            2107 1970-01-01 01:00 whoami-2.0.2/Cargo.toml
-rw-r--r-- 0/0            1825 2006-07-24 02:21 whoami-2.0.2/Cargo.toml.orig
-rw-r--r-- 0/0            4491 2006-07-24 02:21 whoami-2.0.2/README.md
-rw-r--r-- 0/0            5234 2006-07-24 02:21 whoami-2.0.2/src/api.rs
-rw-r--r-- 0/0            3515 2006-07-24 02:21 whoami-2.0.2/src/arch.rs
-rw-r--r-- 0/0            1129 2006-07-24 02:21 whoami-2.0.2/src/conversions.rs
-rw-r--r-- 0/0            3507 2006-07-24 02:21 whoami-2.0.2/src/cpu_arch.rs
-rw-r--r-- 0/0            3117 2006-07-24 02:21 whoami-2.0.2/src/desktop_env.rs
-rw-r--r-- 0/0            2307 2006-07-24 02:21 whoami-2.0.2/src/error.rs
-rw-r--r-- 0/0           12547 2006-07-24 02:21 whoami-2.0.2/src/langs.rs
-rw-r--r-- 0/0            3723 2006-07-24 02:21 whoami-2.0.2/src/lib.rs
-rw-r--r-- 0/0            1540 2006-07-24 02:21 whoami-2.0.2/src/os/daku.rs
-rw-r--r-- 0/0            3648 2006-07-24 02:21 whoami-2.0.2/src/os/redox.rs
-rw-r--r-- 0/0            3888 2006-07-24 02:21 whoami-2.0.2/src/os/stub.rs
-rw-r--r-- 0/0           21076 2006-07-24 02:21 whoami-2.0.2/src/os/unix.rs
-rw-r--r-- 0/0            2601 2006-07-24 02:21 whoami-2.0.2/src/os/wasite.rs
-rw-r--r-- 0/0            6288 2006-07-24 02:21 whoami-2.0.2/src/os/web.rs
-rw-r--r-- 0/0           14946 2006-07-24 02:21 whoami-2.0.2/src/os/windows.rs
-rw-r--r-- 0/0            5490 2006-07-24 02:21 whoami-2.0.2/src/os.rs
-rw-r--r-- 0/0            1110 2006-07-24 02:21 whoami-2.0.2/src/platform.rs
-rw-r--r-- 0/0             161 2006-07-24 02:21 whoami-2.0.2/src/result.rs
```

After this PR:

```
$ cargo publish --dry-run
$ tar -tzvf ../target/package/whoami-2.0.2.crate
-rw-r--r-- 0/0             100 1970-01-01 01:00 whoami-2.0.2/.cargo_vcs_info.json
-rw-r--r-- 0/0            4763 1970-01-01 01:00 whoami-2.0.2/Cargo.lock
-rw-r--r-- 0/0            2098 1970-01-01 01:00 whoami-2.0.2/Cargo.toml
-rw-r--r-- 0/0            1816 2006-07-24 02:21 whoami-2.0.2/Cargo.toml.orig
-rw-r--r-- 0/0            9723 2006-07-24 02:21 whoami-2.0.2/LICENSE_APACHE
-rw-r--r-- 0/0            1338 2006-07-24 02:21 whoami-2.0.2/LICENSE_BOOST
-rw-r--r-- 0/0            1036 2006-07-24 02:21 whoami-2.0.2/LICENSE_MIT
-rw-r--r-- 0/0            4491 2006-07-24 02:21 whoami-2.0.2/README.md
-rw-r--r-- 0/0            5234 2006-07-24 02:21 whoami-2.0.2/src/api.rs
-rw-r--r-- 0/0            3515 2006-07-24 02:21 whoami-2.0.2/src/arch.rs
-rw-r--r-- 0/0            1129 2006-07-24 02:21 whoami-2.0.2/src/conversions.rs
-rw-r--r-- 0/0            3507 2006-07-24 02:21 whoami-2.0.2/src/cpu_arch.rs
-rw-r--r-- 0/0            3117 2006-07-24 02:21 whoami-2.0.2/src/desktop_env.rs
-rw-r--r-- 0/0            2307 2006-07-24 02:21 whoami-2.0.2/src/error.rs
-rw-r--r-- 0/0           12547 2006-07-24 02:21 whoami-2.0.2/src/langs.rs
-rw-r--r-- 0/0            3723 2006-07-24 02:21 whoami-2.0.2/src/lib.rs
-rw-r--r-- 0/0            1540 2006-07-24 02:21 whoami-2.0.2/src/os/daku.rs
-rw-r--r-- 0/0            3648 2006-07-24 02:21 whoami-2.0.2/src/os/redox.rs
-rw-r--r-- 0/0            3888 2006-07-24 02:21 whoami-2.0.2/src/os/stub.rs
-rw-r--r-- 0/0           21076 2006-07-24 02:21 whoami-2.0.2/src/os/unix.rs
-rw-r--r-- 0/0            2601 2006-07-24 02:21 whoami-2.0.2/src/os/wasite.rs
-rw-r--r-- 0/0            6288 2006-07-24 02:21 whoami-2.0.2/src/os/web.rs
-rw-r--r-- 0/0           14946 2006-07-24 02:21 whoami-2.0.2/src/os/windows.rs
-rw-r--r-- 0/0            5490 2006-07-24 02:21 whoami-2.0.2/src/os.rs
-rw-r--r-- 0/0            1110 2006-07-24 02:21 whoami-2.0.2/src/platform.rs
-rw-r--r-- 0/0             161 2006-07-24 02:21 whoami-2.0.2/src/result.rs
```