### PR TITLE
Add dependency objc2-system-configuration for MacOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "cfg-if"
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -57,6 +57,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,18 +82,18 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -88,9 +106,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -105,12 +123,20 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "wasi"
-version = "0.13.0+wasi-0.2.0"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "652cd73449d0b957a2743b70c72d79d34a5fa505696488f4ca90b46f6da94118"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "bitflags",
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -124,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -137,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -147,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -160,18 +186,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -183,6 +209,7 @@ version = "2.1.0"
 dependencies = [
  "libc",
  "libredox",
+ "objc2-system-configuration",
  "wasite",
  "web-sys",
 ]
@@ -198,10 +225,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.21.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "026d24a27f6712541fa534f2954bd9e0eb66172f033c2157c0f31d106255c497"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "xtask"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,20 +123,12 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "wasi"
-version = "0.14.7+wasi-0.2.4"
+version = "0.13.0+wasi-0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+checksum = "652cd73449d0b957a2743b70c72d79d34a5fa505696488f4ca90b46f6da94118"
 dependencies = [
- "wasip2",
-]
-
-[[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
+ "bitflags",
+ "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -225,10 +217,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
+name = "wit-bindgen-rt"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "026d24a27f6712541fa534f2954bd9e0eb66172f033c2157c0f31d106255c497"
 
 [[package]]
 name = "xtask"

--- a/whoami/Cargo.toml
+++ b/whoami/Cargo.toml
@@ -25,8 +25,15 @@ include = [
 ]
 rust-version = "1.75"
 
+# Target-specific dependency for apple
+[target.'cfg(target_vendor = "apple")'.dependencies.objc2-system-configuration]
+version = "0.3.2"
+optional = true
+features = ["SCDynamicStore", "SCDynamicStoreCopySpecific"]
+default-features = false
+
 # Target-specific dependency for unix-like
-[target.'cfg(all(any(target_os = "linux", target_os = "macos", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "illumos", target_os = "hurd"), not(target_arch = "wasm32")))'.dependencies.libc]
+[target.'cfg(all(any(target_vendor = "apple", target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "illumos", target_os = "hurd"), not(target_arch = "wasm32")))'.dependencies.libc]
 version = "0.2.180"
 optional = true
 features = []
@@ -59,7 +66,13 @@ default = ["std", "wasi-wasite", "wasm-web"]
 # Instead of interfacing with the OS, force stubs to be used
 force-stub = []
 # Allow interfacing with the standard library and OS.
-std = ["dep:libc", "dep:libredox", "libc?/std", "web-sys?/std"]
+std = [
+    "dep:libc",
+    "dep:libredox",
+    "dep:objc2-system-configuration",
+    "libc?/std",
+    "web-sys?/std",
+]
 # Assume a wasite conforming environment on WASI (takes precedence over
 # `wasm-web`).
 wasi-wasite = ["dep:wasite"]

--- a/whoami/src/os.rs
+++ b/whoami/src/os.rs
@@ -27,8 +27,8 @@
         not(any(feature = "force-stub", target_arch = "wasm32")),
         feature = "std",
         any(
+            target_vendor = "apple",
             target_os = "linux",
-            target_os = "macos",
             target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "netbsd",

--- a/whoami/src/os/unix.rs
+++ b/whoami/src/os/unix.rs
@@ -1,20 +1,5 @@
-#[cfg(any(
-    target_os = "linux",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "illumos",
-    target_os = "hurd",
-))]
-use std::env;
-#[cfg(target_os = "macos")]
 use std::{
-    ffi::{c_long, c_uchar, c_void, OsStr},
-    os::unix::ffi::OsStrExt,
-    ptr::null_mut,
-};
-use std::{
+    borrow::Cow,
     ffi::{CStr, OsString},
     fs, io, mem,
     os::unix::ffi::OsStringExt,
@@ -27,32 +12,6 @@ use crate::{
     CpuArchitecture, DesktopEnvironment, Error, LanguagePreferences, Platform,
     Result,
 };
-
-#[cfg(target_os = "macos")]
-#[link(name = "CoreFoundation", kind = "framework")]
-extern "system" {
-    fn CFStringGetCString(
-        the_string: *mut c_void,
-        buffer: *mut u8,
-        buffer_size: c_long,
-        encoding: u32,
-    ) -> c_uchar;
-    fn CFStringGetLength(the_string: *mut c_void) -> c_long;
-    fn CFStringGetMaximumSizeForEncoding(
-        length: c_long,
-        encoding: u32,
-    ) -> c_long;
-    fn CFRelease(cf: *const c_void);
-}
-
-#[cfg(target_os = "macos")]
-#[link(name = "SystemConfiguration", kind = "framework")]
-extern "system" {
-    fn SCDynamicStoreCopyComputerName(
-        store: *mut c_void,
-        encoding: *mut u32,
-    ) -> *mut c_void;
-}
 
 enum Name {
     User,
@@ -166,48 +125,26 @@ impl Target for Os {
     }
 
     fn devicename(self) -> Result<OsString> {
-        #[cfg(target_os = "macos")]
+        #[cfg(target_vendor = "apple")]
         {
-            fn os_from_cfstring(string: *mut c_void) -> OsString {
-                if string.is_null() {
-                    return String::new().into();
-                }
+            use std::ptr::null_mut;
 
-                unsafe {
-                    let len = CFStringGetLength(string);
-                    let capacity = CFStringGetMaximumSizeForEncoding(
-                        len,
-                        134_217_984, /* UTF8 */
-                    ) + 1;
-                    let mut out = Vec::with_capacity(capacity as usize);
-                    if CFStringGetCString(
-                        string,
-                        out.as_mut_ptr(),
-                        capacity,
-                        134_217_984, /* UTF8 */
-                    ) != 0
-                    {
-                        // Remove trailing NUL byte
-                        out.set_len(strlen::<Nul>(out.as_ptr().cast()));
-                        out.shrink_to_fit();
-                        CFRelease(string);
-                        OsString::from_vec(out)
-                    } else {
-                        CFRelease(string);
-                        String::new().into()
-                    }
-                }
-            }
+            use objc2_system_configuration::SCDynamicStore;
 
-            let out = os_from_cfstring(unsafe {
-                SCDynamicStoreCopyComputerName(null_mut(), null_mut())
-            });
+            let Some(name) =
+                (unsafe { SCDynamicStore::computer_name(None, null_mut()) })
+            else {
+                return Err(Error::missing_record());
+            };
+            // this should be able to convert whichever encoding is being used
+            // to UTF-8, so we shouldn't have to worry about invalid codepoints.
+            let name = name.to_string();
 
-            if out.as_bytes().is_empty() {
+            if name.is_empty() {
                 return Err(Error::empty_record());
             }
 
-            Ok(out)
+            Ok(name.into())
         }
 
         #[cfg(target_os = "illumos")]
@@ -303,7 +240,7 @@ impl Target for Os {
     }
 
     fn distro(self) -> Result<String> {
-        #[cfg(target_os = "macos")]
+        #[cfg(target_vendor = "apple")]
         {
             fn distro_xml(data: String) -> Result<String> {
                 let mut product_name = None;
@@ -377,7 +314,7 @@ impl Target for Os {
             }
         }
 
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(target_vendor = "apple"))]
         {
             let program =
                 fs::read("/etc/os-release").map_err(Error::from_io)?;
@@ -413,16 +350,16 @@ impl Target for Os {
     }
 
     fn desktop_env(self) -> Option<DesktopEnvironment> {
-        #[cfg(target_os = "macos")]
-        let env = OsStr::new("Aqua");
+        #[cfg(target_vendor = "apple")]
+        let env: Cow<'static, str> = "Aqua".into();
 
-        #[cfg(not(target_os = "macos"))]
-        let env = env::var_os("XDG_SESSION_DESKTOP")
-            .or_else(|| env::var_os("DESKTOP_SESSION"))
-            .or_else(|| env::var_os("XDG_CURRENT_DESKTOP"))?;
-
-        // convert `OsStr` to `Cow`
-        let env = env.to_string_lossy();
+        #[cfg(not(target_vendor = "apple"))]
+        let env: Cow<'static, str> = std::env::var_os("XDG_SESSION_DESKTOP")
+            .or_else(|| std::env::var_os("DESKTOP_SESSION"))
+            .or_else(|| std::env::var_os("XDG_CURRENT_DESKTOP"))?
+            .into_string()
+            .unwrap_or_else(|e| e.to_string_lossy().into_owned())
+            .into();
 
         Some(if env.eq_ignore_ascii_case("AQUA") {
             DesktopEnvironment::Aqua
@@ -458,7 +395,7 @@ impl Target for Os {
             Platform::Linux
         }
 
-        #[cfg(target_os = "macos")]
+        #[cfg(target_vendor = "apple")]
         {
             Platform::Mac
         }


### PR DESCRIPTION
Removes all hand-written FFI bindings from unix impl / deferred to FFI crates

## Testing / Verification

<!-- Please describe any testing or verification done here -->
