### PR TITLE
Bump version to 2.1.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish to crates.io
+on:
+  push:
+    tags: ['v*']
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: Publishing
+    permissions:
+      id-token: write
+    steps:
+    - uses: taiki-e/checkout-action@v1
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
+    - run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "libc",
  "libredox",

--- a/whoami/Cargo.toml
+++ b/whoami/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whoami"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 license = "Apache-2.0 OR BSL-1.0 OR MIT"
 documentation = "https://docs.rs/whoami"
@@ -55,7 +55,7 @@ default-features = false
 
 # Target-specific dependency for web browser
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi"), not(daku)))'.dependencies.web-sys]
-version = "0.3.77"
+version = "0.3.85"
 optional = true
 features = ["Navigator", "Document", "Window", "Location"]
 default-features = false


### PR DESCRIPTION
# Release v2.1.1

## Regression testing plan for only unix this time

Set passwords / hostnames to "test" when prompted.

 - [x] Testing complete on Fedora Silverblue 43.
    <details><summary>Linux / Fedora Silverblue Testing</summary>
    Open a terminal (outside of toolbx), and:

    ```rust
    cargo run --example whoami-demo
    cargo run --example whoami-demo --release
    cargo run --example os-strings
    cargo run --example os-strings --release
    ```

    Expect to see something like:

    ```console
    WhoAmI 2.0.0

    User's Language        whoami::lang_prefs():          Collation=en/US:en,CharClasses=en/US:en,Monetary=en/US:en,Messages=en/US:en,Numeric=en/US:en,Time=en/US:en
    User's Name            whoami::realname():            Jeryn Lau
    User's Username        whoami::username():            jerynlau
    User's Username        whoami::account():             jerynlau
    Device's Pretty Name   whoami::devicename():          Ta'ra
    Device's Hostname      whoami::hostname():            taiara
    Device's Platform      whoami::platform():            Linux
    Device's OS Distro     whoami::distro():              Fedora Linux 43.20251220.0 (Silverblue)
    Device's Desktop Env.  whoami::desktop_env():         Gnome
    Device's CPU Arch      whoami::cpu_arch():            x86_64
    ```

    ```console
    WhoAmI 2.0.0

    User's Language        whoami::lang_prefs():            LanguagePreferences { fallbacks: [Language { lang: [101, 110], country: Some([85, 83]) }, Language { lang: [101, 110], country: None }], collation: None, char_classes: None, monetary: None, messages: None, numeric: None, time: None }
    User's Name            whoami::realname_os():           "Jeryn Lau"
    User's Username        whoami::username_os():           "jerynlau"
    User's Account         whoami::account_os():            "jerynlau"
    Device's Pretty Name   whoami::devicename_os():         "Ta\'ra"
    Device's Hostname      whoami::hostname():              "taiara"
    Device's Platform      whoami::platform():              Linux
    Device's OS Distro     whoami::distro():                Ok("Fedora Linux 43.20251220.0 (Silverblue)")
    Device's Desktop Env.  whoami::desktop_env():           Some(Gnome)
    Device's CPU Arch      whoami::cpu_arch():              X64
    ```

    Now, `toolbx enter`, and do the same.  Expecting something like:

    ```console
    WhoAmI 2.0.0

    User's Language        whoami::lang_prefs():          Collation=en/US:en,CharClasses=en/US:en,Monetary=en/US:en,Messages=en/US:en,Numeric=en/US:en,Time=en/US:en
    User's Name            whoami::realname():            Jeryn Lau
    User's Username        whoami::username():            jerynlau
    User's Username        whoami::account():             jerynlau
    Device's Pretty Name   whoami::devicename():          <unknown>
    Device's Hostname      whoami::hostname():            toolbx
    Device's Platform      whoami::platform():            Linux
    Device's OS Distro     whoami::distro():              Fedora Linux 43 (Toolbx Container Image)
    Device's Desktop Env.  whoami::desktop_env():         Gnome
    Device's CPU Arch      whoami::cpu_arch():            x86_64
    ```

    ```console
    WhoAmI 2.0.0

    User's Language        whoami::lang_prefs():            LanguagePreferences { fallbacks: [Language { lang: [101, 110], country: Some([85, 83]) }, Language { lang: [101, 110], country: None }], collation: None, char_classes: None, monetary: None, messages: None, numeric: None, time: None }
    User's Name            whoami::realname_os():           "Jeryn Lau"
    User's Username        whoami::username_os():           "jerynlau"
    User's Account         whoami::account_os():            "jerynlau"
    Device's Pretty Name   whoami::devicename_os():         "<unknown>"
    Device's Hostname      whoami::hostname():              "toolbx"
    Device's Platform      whoami::platform():              Linux
    Device's OS Distro     whoami::distro():                Ok("Fedora Linux 43 (Toolbx Container Image)")
    Device's Desktop Env.  whoami::desktop_env():           Some(Gnome)
    Device's CPU Arch      whoami::cpu_arch():              X64
    ```
    </details>
 - [x] Testing complete on Ubuntu Linux 24.04.1 LTS
    <details><summary>Ubuntu Virtualized on Fedora Silverblue Testing</summary>
    <https://ubuntu.com/download/desktop>

    Install from file within GNOME boxes (keep all defaults).

    In Ubuntu Installer, do default installation.

    ```shell
    sudo apt install git curl gcc tig # y
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh # 1
    source "$HOME/.cargo/env"
    ```

    Clone whoami, open a terminal, and run:

    ```rust
    cargo run --example whoami-demo
    cargo run --example whoami-demo --release
    ```

    Expect to see something like:

    ```console
    WhoAmI 2.0.0

    User's Language        whoami::lang_prefs():          Collation=en/US:en,CharClasses=en/US:en,Monetary=en/US:en,Messages=en/US:en,Numeric=en/US:en,Time=en/US:en
    User's Name            whoami::realname():            Jeryn Lau
    User's Username        whoami::username():            jeryn-lau
    User's Username        whoami::account():             jeryn-lau
    Device's Pretty Name   whoami::devicename():          Taiara
    Device's Hostname      whoami::hostname():            Taiara
    Device's Platform      whoami::platform():            Linux
    Device's OS Distro     whoami::distro():              Ubuntu 25.10
    Device's Desktop Env.  whoami::desktop_env():         Ubuntu
    Device's CPU Arch      whoami::cpu_arch():            x86_64
    ```
    </details>
 - [x] Testing complete on macOS Catalina
    <details><summary>MacOS Testing</summary>
    Clone whoami, and run:

    ```rust
    cargo run --example whoami-demo
    cargo run --example whoami-demo --release
    ```

    Expect to see something like:

    ```console
    WhoAmI 2.0.0

    User's Language        whoami::lang_prefs():          Collation=en/US:en,CharClasses=en/US:en,Monetary=en/US:en,Messages=en/US:en,Numeric=en/US:en,Time=en/US:en
    User's Name            whoami::realname():            Aldaron Lau
    User's Username        whoami::username():            aldaronlau
    User's Username        whoami::account():             aldaronlau
    Device's Pretty Name   whoami::devicename():          Aldaron’s MacBook Air
    Device's Hostname      whoami::hostname():            Aldarons-MacBook-Air.local
    Device's Platform      whoami::platform():            macOS
    Device's OS Distro     whoami::distro():              Mac OS X 10.15.7
    Device's Desktop Env.  whoami::desktop_env():         Aqua
    Device's CPU Arch      whoami::cpu_arch():            x86_64
    ```
    </details>
 - [x] Testing complete on FreeBSD
    <details><summary>FreeBSD (virtualized on Fedora Silverblue) Testing</summary>
    Download from within GNOME Boxes.

    Set 4 GiB memory, and 20 GiB Storage limit

    Go through the installation process, keeping all defaults.

    ### Install packages

    Log in as root

    ```shell
    pkg install git
    ```

    Log in as you

    ```shell
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh # 1
    . "$HOME/.cargo/env"
    git clone https://github.com/ardaku/whoami.git
    cd whoami
    # run both debug and release
    cargo run --example whoami-demo
    cargo run --example whoami-demo --release
    ```

    Expect to see something like:

    ```console
    WhoAmI 2.0.0

    User's Language        whoami::lang_prefs():          Collation=,CharClasses=,Monetary=,Messages=,Numeric=,Time=
    User's Name            whoami::realname():            Jeryn Lau
    User's Username        whoami::username():            jerynlau
    User's Username        whoami::account():             jerynlau
    Device's Pretty Name   whoami::devicename():          <unknown>
    Device's Hostname      whoami::hostname():            testing
    Device's Platform      whoami::platform():            BSD
    Device's OS Distro     whoami::distro():              FreeBSD 14.3-RELEASE
    Device's Desktop Env.  whoami::desktop_env():         <unknown>
    Device's CPU Arch      whoami::cpu_arch():            x86_64
    ```
    </details>
 - [x] Testing complete on illumos
    <details><summary>Tribblix (virtualized on Fedora Silverblue) Testing</summary>
    <http://www.tribblix.org/download.html>

    Download the 64-bit x86/x64 standard image.

    Install it in GNOME Boxes (select operating system OpenIndiana Hipster).

    Set 4 GiB memory, and 16 GiB Storage limit

    Login as `jack` (password `jack`)

    ```shell
    su - root # password `tribblix`
    format # 0, quit
    ./live_install -G c1t0d0 develop # replace c1t0d0 with disk
    reboot -p
    ```

    Login as `jack` (password `jack`)

    Now, install Rust (use bash instead of sh, sh doesn't work)

    ```shell
    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | bash # 1
    source "$HOME/.cargo/env"
    ```

    ### Testing

    ```shell
    git clone https://github.com/ardaku/whoami.git
    cd whoami
    # run both debug and release
    cargo run --example whoami-demo
    cargo run --example whoami-demo --release
    ```

    Expected output is

    ```console
    WhoAmI 2.0.0

    User's Language        whoami::lang_prefs():          Collation=,CharClasses=,Monetary=,Messages=,Numeric=,Time=
    User's Name            whoami::realname():            Tribblix Jack
    User's Username        whoami::username():            jack
    User's Username        whoami::account():             jack
    Device's Pretty Name   whoami::devicename():          tribblix
    Device's Hostname      whoami::hostname():            tribblix
    Device's Platform      whoami::platform():            illumos
    Device's OS Distro     whoami::distro():              Tribblix
    Device's Desktop Env.  whoami::desktop_env():         XFCE
    Device's CPU Arch      whoami::cpu_arch():            x86_64
    ```
    </details>

# Changelog

## Added

 - Support for other Apple targets (untested)

## Changed

 - Improved unix-like implementations - now depends on libc, and objc2-system-configuration on macOS
 - Updated web-sys to 0.3.85