### PR TITLE
Collapse `if` in match on unix

### DIFF
--- a/whoami/src/os/unix.rs
+++ b/whoami/src/os/unix.rs
@@ -260,10 +260,10 @@ impl Target for Os {
                                     "ProductUserVisibleVersion" => {
                                         set_user_visible_version = true
                                     }
-                                    "ProductVersion" => {
-                                        if user_visible_version.is_none() {
-                                            set_user_visible_version = true
-                                        }
+                                    "ProductVersion"
+                                        if user_visible_version.is_none() =>
+                                    {
+                                        set_user_visible_version = true
                                     }
                                     _ => {}
                                 }


### PR DESCRIPTION
Fixes a nightly clippy warning