### PR TITLE
Fix compilation on wasm32-wasip2

### DIFF
--- a/whoami/src/conversions.rs
+++ b/whoami/src/conversions.rs
@@ -18,7 +18,11 @@ pub(crate) fn string_from_os(string: OsString) -> Result<String> {
 
     #[cfg(any(
         all(not(target_os = "windows"), not(target_arch = "wasm32")),
-        all(target_arch = "wasm32", target_os = "wasi"),
+        all(
+            target_arch = "wasm32",
+            target_os = "wasi",
+            not(target_env = "p2")
+        ),
     ))]
     {
         #[cfg(not(target_os = "wasi"))]
@@ -34,6 +38,7 @@ pub(crate) fn string_from_os(string: OsString) -> Result<String> {
     #[cfg(any(
         target_os = "windows",
         all(target_arch = "wasm32", not(target_os = "wasi")),
+        target_env = "p2",
     ))]
     {
         string

--- a/whoami/src/conversions.rs
+++ b/whoami/src/conversions.rs
@@ -38,7 +38,7 @@ pub(crate) fn string_from_os(string: OsString) -> Result<String> {
     #[cfg(any(
         target_os = "windows",
         all(target_arch = "wasm32", not(target_os = "wasi")),
-        target_env = "p2",
+        all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"),
     ))]
     {
         string


### PR DESCRIPTION
Hey, with tokio 1.51 shipping wasm32-wasip2 networking support ([tokio-rs/tokio#7933](https://github.com/tokio-rs/tokio/pull/7933)), it's now possible to start porting crates like `tokio-postgres` to wasip2. `whoami` is a dependency of `tokio-postgres` and currently the first thing that fails to compile on that target.

The issue is that `std::os::wasi::ffi::OsStringExt` requires `#![feature(wasip2)]` on `wasm32-wasip2`, but the cfg gate uses `target_os = "wasi"` which matches both wasip1 (where the import is stable) and wasip2 (where it's not).

This PR uses `target_env` to distinguish them — `"p1"` for wasip1, `"p2"` for wasip2. wasip2 routes to the `into_string()` fallback (same path Windows already uses). No feature flags, works on stable, no impact on existing targets.

An alternative would be `#![cfg_attr(target_env = "p2", feature(wasip2))]` to enable the unstable API directly, but that forces nightly on wasip2 users.

## Testing / Verification

```
cargo check                          # native — passes
cargo check --target wasm32-wasip2   # wasip2 — passes (was failing)
```